### PR TITLE
fix(cap_im_qq): fix qq send file

### DIFF
--- a/components/claw_capabilities/cap_im_qq/src/cap_im_qq.c
+++ b/components/claw_capabilities/cap_im_qq/src/cap_im_qq.c
@@ -1349,6 +1349,7 @@ static esp_err_t cap_im_qq_upload_media(const char *chat_id,
                                         char **out_file_info)
 {
     struct stat st;
+    const char *base_name = NULL;
     cJSON *body = NULL;
     char *path_buf = NULL;
     char *file_b64 = NULL;
@@ -1385,6 +1386,12 @@ static esp_err_t cap_im_qq_upload_media(const char *chat_id,
     cJSON_AddNumberToObject(body, "file_type", (double)file_type);
     cJSON_AddBoolToObject(body, "srv_send_msg", false);
     cJSON_AddStringToObject(body, "file_data", file_b64);
+    if (file_type == CAP_IM_QQ_FILE_TYPE_FILE) {
+        base_name = cap_im_qq_basename(path);
+        if (base_name && base_name[0]) {
+            cJSON_AddStringToObject(body, "file_name", base_name);
+        }
+    }
     json_str = cJSON_PrintUnformatted(body);
     cJSON_Delete(body);
     free(file_b64);


### PR DESCRIPTION
## Description

This PR fixes QQ generic file uploads so the original local basename is sent as `file_name` metadata to the QQ media upload API.

Before this change, non-image files were uploaded without explicit filename metadata, which could cause QQ clients to show files without a clear filename. This was especially inconvenient for returned logs, json and scripts.



## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] Documentation is updated as needed.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
