### PR TITLE
boards: add M5Stack CoreS3 board support

### DIFF
--- a/application/basic_demo/boards/m5stack_cores3/board_devices.yaml
+++ b/application/basic_demo/boards/m5stack_cores3/board_devices.yaml
@@ -1,0 +1,135 @@
+version: 1.0.0
+# Devices Configuration
+devices:
+
+  - name: gpio_expander
+    chip: aw9523b
+    type: gpio_expander
+    version: default
+    dependencies:
+      esp_io_expander_aw9523b:
+        override_path: "${BOARD_PATH}/components/esp_io_expander_aw9523b"
+        require: public
+    config:
+      max_pins: 16
+      # When pin1 and pin5 of the IO expansion chip are driven low,
+      # the device can be powered via the Grove/DC interface, but using
+      # SD card and LCD simultaneously may cause a crash issue.
+      # pin 1  = BUS_EN   (Grove / ext 5V)
+      # pin 15 = BOOST_EN (5V boost converter; must be on together with BUS_EN)
+      output_io_mask: [0, 1, 2, 4, 5, 8, 9, 10, 11, 15]
+      output_io_level_mask: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      input_io_mask: NULL
+    peripherals:
+      - name: i2c_master
+        i2c_addr: [0xb0]
+
+  - name: axp2101_power_manager
+    chip: axp2101
+    type: custom
+    version: default
+    config:
+      frequency: 400000
+      i2c_addr: 0x34
+    peripherals:
+      - name: i2c_master
+
+  - name: audio_dac
+    chip: aw88298
+    type: audio_codec
+    version: default
+    config:
+      adc_enabled: false
+      dac_enabled: true
+      dac_max_channel: 1
+      dac_channel_mask: "1"
+      dac_init_gain: 0
+      # Audio processing settings
+      mclk_enabled: false
+    peripherals:
+      - name: i2s_audio_out
+      - name: i2c_master
+        address: 0x6c
+        frequency: 400000
+
+  - name: audio_adc
+    chip: es7210
+    type: audio_codec
+    version: default
+    config:
+      adc_enabled: true
+      adc_max_channel: 4
+      adc_channel_mask: "0011"
+      adc_init_gain: 0
+    peripherals:
+      - name: i2s_audio_in
+      - name: i2c_master
+        address: 0x80
+        frequency: 400000
+
+  # SD Card Configuration, it is recommended not to use it with LCD.
+  # Using them simultaneously may cause SD card mount failure or program
+  # crashes due to SPI resource conflicts.
+  # - name: fs_sdcard
+  #   type: fs_fat
+  #   sub_type: spi
+  #   config:
+  #     sub_config:
+  #       cs_gpio_num: 4
+  #       frequency: SDMMC_FREQ_DEFAULT
+  #   peripherals:
+  #     - name: spi_master
+
+  - name: display_lcd
+    chip: ili9341
+    type: display_lcd
+    sub_type: spi
+    version: default
+    dependencies:
+      espressif/esp_lcd_ili9341: "*"
+    config:
+      mirror_x: false
+      mirror_y: false
+      x_max: 320
+      y_max: 240
+      invert_color: true  # Required for M5Stack CoreS3 LCD
+      io_spi_config:
+        cs_gpio_num: 3
+        dc_gpio_num: 35
+        spi_mode: 0
+        pclk_hz: 40000000
+        flags:
+          sio_mode: true
+
+      lcd_panel_config:
+        reset_gpio_num: -1
+        rgb_ele_order: LCD_RGB_ELEMENT_ORDER_BGR
+        bits_per_pixel: 16
+        data_endian: LCD_RGB_DATA_ENDIAN_BIG
+        flags:
+          reset_active_high: true
+
+    peripherals:
+      - name: spi_master
+
+  # Touch Panel Configuration
+  - name: lcd_touch
+    chip: ft5x06
+    type: lcd_touch_i2c
+    version: default
+    dependencies:
+      esp_lcd_touch:
+        version: "*"
+        require: public
+      espressif/esp_lcd_touch_ft5x06: "^1.0.0"
+    config:
+      io_i2c_config:
+        dev_addr: [0x38]
+        lcd_cmd_bits: 8
+        scl_speed_hz: 400000
+        peripherals:
+          - name: i2c_master
+
+      touch_config:
+        x_max: 320
+        y_max: 240

--- a/application/basic_demo/boards/m5stack_cores3/board_info.yaml
+++ b/application/basic_demo/boards/m5stack_cores3/board_info.yaml
@@ -1,0 +1,5 @@
+board: m5stack_cores3
+chip: esp32s3
+version: 1.0.0
+description: "M5Stack CoreS3 Development Board"
+manufacturer: "M5Stack"

--- a/application/basic_demo/boards/m5stack_cores3/board_peripherals.yaml
+++ b/application/basic_demo/boards/m5stack_cores3/board_peripherals.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+# Peripherals Configuration
+peripherals:
+  - name: i2c_master
+    type: i2c
+    role: master
+    config:
+      port: 0
+      pins:
+        sda: 12
+        scl: 11
+
+  # I2S Standard Configuration (48 kHz stereo)
+  - name: i2s_audio_out
+    type: i2s
+    role: master
+    format: std-out
+    config: &i2s0_config
+      port: 0
+      # Clock configuration
+      sample_rate_hz: 48000
+      mclk_multiple: 256
+
+      # Slot configuration
+      data_bit_width: 16
+      slot_bit_width: I2S_SLOT_BIT_WIDTH_AUTO
+      slot_mode: I2S_SLOT_MODE_STEREO
+      slot_mask: I2S_STD_SLOT_BOTH
+      ws_width: 16
+
+      # GPIO configuration
+      pins:
+        mclk: 0
+        bclk: 34
+        ws: 33
+        dout: 13
+        din: 14
+
+  - name: i2s_audio_in
+    type: i2s
+    role: master
+    format: std-in
+    config: *i2s0_config
+
+  # LCD SPI Configuration
+  - name: spi_master
+    type: spi
+    role: master
+    config:
+      # spi_bus_config_t fields
+      spi_bus_config:
+        spi_port: SPI2_HOST
+        mosi_io_num: 37
+        miso_io_num: 35
+        sclk_io_num: 36
+        max_transfer_sz: 3600
+
+  # PA CONTROL (AW88298 power amplifier enable)
+  - name: gpio_pa_control
+    type: gpio
+    role: io
+    config:
+      pin: 46
+      mode: GPIO_MODE_OUTPUT
+      pull_up: true

--- a/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/CMakeLists.txt
+++ b/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRC_DIRS "."
+    INCLUDE_DIRS "include"
+    REQUIRES driver
+             esp_driver_i2c
+    )

--- a/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/esp_io_expander_aw9523b.c
+++ b/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/esp_io_expander_aw9523b.c
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include "esp_check.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_io_expander_aw9523b.h"
+
+/* I2C communication related */
+#define I2C_TIMEOUT_MS (1000)
+#define I2C_CLK_SPEED  (400000)
+
+/* Default register value on power-up */
+#define DIR_REG_DEFAULT_VAL (0x0000)
+#define OUT_REG_DEFAULT_VAL (0x0000)
+
+static char *TAG = "AW9523B";
+
+static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    uint16_t temp = 0;
+    ESP_RETURN_ON_ERROR(i2c_master_transmit_receive(aw9523b->i2c_handle, (uint8_t[]) {AW9523B_REG_INPUT0}, 1, (uint8_t *)&temp, sizeof(temp), I2C_TIMEOUT_MS), TAG, "Read input reg failed");
+    *value = temp;
+    return ESP_OK;
+}
+
+static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    value &= 0xffff;
+    uint8_t data[] = {AW9523B_REG_OUTPUT0, value & 0xff, value >> 8};
+    ESP_RETURN_ON_ERROR(i2c_master_transmit(aw9523b->i2c_handle, data, sizeof(data), I2C_TIMEOUT_MS), TAG, "Write output reg failed");
+    aw9523b->regs.output = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    *value = aw9523b->regs.output;
+    return ESP_OK;
+}
+
+static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    value &= 0xffff;
+    uint8_t data[] = {AW9523B_REG_CONFIG0, value & 0xff, value >> 8};
+    ESP_RETURN_ON_ERROR(i2c_master_transmit(aw9523b->i2c_handle, data, sizeof(data), I2C_TIMEOUT_MS), TAG, "Write direction reg failed");
+    aw9523b->regs.direction = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    *value = aw9523b->regs.direction;
+    return ESP_OK;
+}
+
+static esp_err_t reset(esp_io_expander_t *handle)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    uint8_t data[] = {AW9523B_REG_SOFTRESET, 0};
+    ESP_RETURN_ON_ERROR(i2c_master_transmit(aw9523b->i2c_handle, data, sizeof(data), I2C_TIMEOUT_MS), TAG, "Write direction reg failed");
+    ESP_RETURN_ON_ERROR(write_direction_reg(handle, DIR_REG_DEFAULT_VAL), TAG, "Write dir reg failed");
+    ESP_RETURN_ON_ERROR(write_output_reg(handle, OUT_REG_DEFAULT_VAL), TAG, "Write output reg failed");
+    return ESP_OK;
+}
+
+static esp_err_t del(esp_io_expander_t *handle)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    ESP_RETURN_ON_ERROR(i2c_master_bus_rm_device(aw9523b->i2c_handle), TAG, "Remove I2C device failed");
+    free(aw9523b);
+    return ESP_OK;
+}
+
+esp_err_t esp_io_expander_new_aw9523b(i2c_master_bus_handle_t i2c_bus, uint32_t dev_addr, esp_io_expander_handle_t *handle_ret)
+{
+    ESP_RETURN_ON_FALSE(handle_ret != NULL, ESP_ERR_INVALID_ARG, TAG, "Invalid handle_ret");
+
+    // Allocate memory for driver object
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)calloc(1, sizeof(esp_io_expander_aw9523b_t));
+    ESP_RETURN_ON_FALSE(aw9523b != NULL, ESP_ERR_NO_MEM, TAG, "Malloc failed");
+
+    // Add new I2C device
+    esp_err_t ret = ESP_OK;
+    const i2c_device_config_t i2c_dev_cfg = {
+        .device_address = dev_addr,
+        .scl_speed_hz = I2C_CLK_SPEED,
+    };
+
+    ESP_GOTO_ON_ERROR(i2c_master_bus_add_device(i2c_bus, &i2c_dev_cfg, &aw9523b->i2c_handle), err, TAG, "Add new I2C device failed");
+
+    aw9523b->base.config.io_count = AW9523B_IO_COUNT;
+    aw9523b->base.config.flags.dir_out_bit_zero = 1;
+    aw9523b->base.read_input_reg = read_input_reg;
+    aw9523b->base.write_output_reg = write_output_reg;
+    aw9523b->base.read_output_reg = read_output_reg;
+    aw9523b->base.write_direction_reg = write_direction_reg;
+    aw9523b->base.read_direction_reg = read_direction_reg;
+    aw9523b->base.del = del;
+    aw9523b->base.reset = reset;
+
+    /* Reset configuration and register status */
+    ESP_GOTO_ON_ERROR(reset(&aw9523b->base), err1, TAG, "Reset failed");
+
+    *handle_ret = &aw9523b->base;
+    return ESP_OK;
+err1:
+    i2c_master_bus_rm_device(aw9523b->i2c_handle);
+err:
+    free(aw9523b);
+    return ret;
+}
+
+esp_err_t esp_io_expander_aw9523b_write_reg(esp_io_expander_handle_t handle, uint8_t reg_addr, uint8_t *data, size_t data_len)
+{
+    esp_io_expander_aw9523b_t *aw9523b = (esp_io_expander_aw9523b_t *)__containerof(handle, esp_io_expander_aw9523b_t, base);
+    uint8_t buf[data_len + 1];
+    buf[0] = reg_addr;
+    memcpy(&buf[1], data, data_len);
+    esp_err_t ret = i2c_master_transmit(aw9523b->i2c_handle, buf, data_len + 1, I2C_TIMEOUT_MS);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Write reg failed");
+    }
+    return ret;
+}

--- a/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/idf_component.yml
+++ b/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/idf_component.yml
@@ -1,0 +1,7 @@
+dependencies:
+  esp_io_expander:
+    public: true
+    version: ^1.0.1
+  idf: '>=5.2'
+description: ESP IO Expander - AW9523B(A)
+version: 1.0.0

--- a/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/include/esp_io_expander_aw9523b.h
+++ b/application/basic_demo/boards/m5stack_cores3/components/esp_io_expander_aw9523b/include/esp_io_expander_aw9523b.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "driver/i2c_master.h"
+#include "esp_io_expander.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+#define AW9523B_IO_COUNT (16)
+
+/* Register address */
+#define AW9523B_I2C_ADDR      0x58  // Default I2C address
+#define AW9523B_REG_INPUT0    0x00
+#define AW9523B_REG_INPUT1    0x01
+#define AW9523B_REG_OUTPUT0   0x02
+#define AW9523B_REG_OUTPUT1   0x03
+#define AW9523B_REG_CONFIG0   0x04
+#define AW9523B_REG_CONFIG1   0x05
+#define AW9523B_REG_LEDMODE0  0x12
+#define AW9523B_REG_LEDMODE1  0x13
+#define AW9523B_REG_INTR0     0x06
+#define AW9523B_REG_INTR1     0x07
+#define AW9523B_REG_ID        0x10
+#define AW9523B_REG_SOFTRESET 0x7F
+#define AW9523B_REG_GCR       0x11
+
+/**
+ * @brief  Device Structure Type
+ *
+ */
+typedef struct {
+    esp_io_expander_t        base;
+    i2c_master_dev_handle_t  i2c_handle;
+    struct {
+        uint16_t  direction;
+        uint16_t  output;
+    } regs;
+} esp_io_expander_aw9523b_t;
+
+/**
+ * @brief  Create a AW9523B IO expander object
+ *
+ * @note   In cores3, the AW9523B IO expander needs to be initialized before the AXP2101 PMU,
+ *         because it is used when enabling the power
+ *
+ * @param[in]   i2c_bus     I2C bus handle. Obtained from `i2c_new_master_bus()`
+ * @param[in]   dev_addr    I2C device address of chip.
+ * @param[out]  handle_ret  Handle to created IO expander object
+ *
+ * @return
+ *       - ESP_OK  Success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_io_expander_new_aw9523b(i2c_master_bus_handle_t i2c_bus, uint32_t dev_addr, esp_io_expander_handle_t *handle_ret);
+
+/**
+ * @brief  Write data to the specified AW9523B register
+ *
+ * @param[in]  handle    IO expander handle
+ * @param[in]  reg_addr  Register address to write
+ * @param[in]  data      Data buffer to write
+ * @param[in]  data_len  Length of data to write
+ *
+ * @return
+ *       - ESP_OK          Success
+ *       - ESP_ERR_NO_MEM  Memory allocation failed
+ *       - ESP_FAIL        I2C transmission failed
+ */
+esp_err_t esp_io_expander_aw9523b_write_reg(esp_io_expander_handle_t handle, uint8_t reg_addr, uint8_t *data, size_t data_len);
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/application/basic_demo/boards/m5stack_cores3/power_manager.c
+++ b/application/basic_demo/boards/m5stack_cores3/power_manager.c
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_check.h"
+#include "driver/i2c_master.h"
+#include "esp_board_device.h"
+#include "esp_board_periph.h"
+#include "gen_board_device_custom.h"
+#include "esp_io_expander.h"
+#include "power_manager.h"
+
+static const char *TAG = "CUSTOM_POWER_MANAGER";
+
+esp_err_t cores3_power_manager_enable(void *device_handle, cores3_power_manager_feature_t feature)
+{
+    i2c_master_dev_handle_t axp2101_h = ((cores3_power_manager_handle_t *)device_handle)->pm_handle;
+    esp_err_t err = ESP_OK;
+    uint8_t data[2];
+    esp_io_expander_handle_t *gpio_exp_aw9523 = NULL;
+
+    err = esp_board_device_get_handle("gpio_expander", (void **)&gpio_exp_aw9523);
+    switch (feature) {
+        case CORES3_POWER_MANAGER_FEATURE_LCD:
+            /* Enable LCD */
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1 << 9), 1);
+            break;
+        case CORES3_POWER_MANAGER_FEATURE_TOUCH:
+            /* Enable Touch */
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1 << 0), 1);
+            break;
+        case CORES3_POWER_MANAGER_FEATURE_5V:
+            /* Enable external 5V output (Grove / BUS_OUT):
+             *   AW9523 P0_1 (pin 1)  = BUS_EN
+             *   AW9523 P1_7 (pin 15) = BOOST_EN (5V boost converter)
+             * Both must be high for the boost rail to appear on the port.
+             */
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1u << 15), 1);
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1u << 1),  1);
+            break;
+        case CORES3_POWER_MANAGER_FEATURE_SD:
+            /* AXP ALDO4 voltage / SD Card / 3V3 */
+            data[0] = 0x95;
+            data[1] = 0b00011100;  // 3V3
+            err |= i2c_master_transmit(axp2101_h, data, sizeof(data), 1000);
+            /* Enable SD */
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1 << 4), 1);
+            break;
+        case CORES3_POWER_MANAGER_FEATURE_SPEAKER:
+            /* AXP ALDO1 voltage / PA PVDD / 1V8 */
+            data[0] = 0x92;
+            data[1] = 0b00001101;  // 1V8
+            err |= i2c_master_transmit(axp2101_h, data, sizeof(data), 1000);
+            /* AXP ALDO2 voltage / Codec / 3V3 */
+            data[0] = 0x93;
+            data[1] = 0b00011100;  // 3V3
+            err |= i2c_master_transmit(axp2101_h, data, sizeof(data), 1000);
+            /* AXP ALDO3 voltage / Codec+Mic / 3V3 */
+            data[0] = 0x94;
+            data[1] = 0b00011100;  // 3V3
+            err |= i2c_master_transmit(axp2101_h, data, sizeof(data), 1000);
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1 << 2), 1);
+            break;
+        case CORES3_POWER_MANAGER_FEATURE_CAMERA:
+            err |= esp_io_expander_set_level(*gpio_exp_aw9523, (1 << 8), 1);
+            break;
+        default:
+            ESP_LOGE(TAG, "Unsupported feature");
+            return ESP_ERR_INVALID_ARG;
+    }
+
+    return err;
+}
+
+int cores3_power_manager_init(void *config, int cfg_size, void **device_handle)
+{
+    ESP_LOGI(TAG, "Initializing power_manager device");
+    dev_custom_axp2101_power_manager_config_t *power_manager_cfg = (dev_custom_axp2101_power_manager_config_t *)config;
+
+    if (strcmp(power_manager_cfg->chip, "axp2101") != 0) {
+        ESP_LOGE(TAG, "Unsupported power_manager chip: %s", power_manager_cfg->chip);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    i2c_master_bus_handle_t i2c_master_handle = NULL;
+    esp_err_t err = esp_board_periph_get_handle(power_manager_cfg->peripheral_name, (void **)&i2c_master_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get i2c handle");
+        return err;
+    }
+
+    cores3_power_manager_handle_t *handle = calloc(1, sizeof(cores3_power_manager_handle_t));
+    if (handle == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate power_manager handle");
+        return ESP_ERR_NO_MEM;
+    }
+
+    const i2c_device_config_t axp2101_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = power_manager_cfg->i2c_addr,
+        .scl_speed_hz = power_manager_cfg->frequency,
+    };
+    err = i2c_master_bus_add_device(i2c_master_handle, &axp2101_config, &handle->pm_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add AXP2101 device to I2C bus");
+        free(handle);
+        return err;
+    }
+
+    cores3_power_manager_enable(handle, CORES3_POWER_MANAGER_FEATURE_SD);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    cores3_power_manager_enable(handle, CORES3_POWER_MANAGER_FEATURE_SPEAKER);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    cores3_power_manager_enable(handle, CORES3_POWER_MANAGER_FEATURE_LCD);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    cores3_power_manager_enable(handle, CORES3_POWER_MANAGER_FEATURE_TOUCH);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    cores3_power_manager_enable(handle, CORES3_POWER_MANAGER_FEATURE_5V);
+    vTaskDelay(pdMS_TO_TICKS(100));
+
+    const uint8_t lcd_bl_en[]  = {0x90, 0xBF};          // AXP DLDO1 Enable
+    ESP_RETURN_ON_ERROR(i2c_master_transmit(handle->pm_handle, lcd_bl_en, sizeof(lcd_bl_en), 1000), TAG, "I2C write failed");
+    const uint8_t lcd_bl_val[] = {0x99, 0b00011000};    // AXP DLDO1 voltage
+    ESP_RETURN_ON_ERROR(i2c_master_transmit(handle->pm_handle, lcd_bl_val, sizeof(lcd_bl_val), 1000), TAG, "I2C write failed");
+
+    *device_handle = handle;
+    return ESP_OK;
+}
+
+int cores3_power_manager_deinit(void *device_handle)
+{
+    if (device_handle == NULL) {
+        ESP_LOGW(TAG, "Power manager device handle is NULL");
+        return ESP_ERR_INVALID_ARG;
+    }
+    cores3_power_manager_handle_t *handle = (cores3_power_manager_handle_t *)device_handle;
+    esp_err_t err = i2c_master_bus_rm_device(handle->pm_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to remove AXP2101 device from I2C bus");
+    }
+    free(handle);
+    return ESP_OK;
+}
+
+CUSTOM_DEVICE_IMPLEMENT(axp2101_power_manager, cores3_power_manager_init, cores3_power_manager_deinit);

--- a/application/basic_demo/boards/m5stack_cores3/power_manager.h
+++ b/application/basic_demo/boards/m5stack_cores3/power_manager.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+#pragma once
+
+#include "driver/i2c_master.h"
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**
+ * @brief  M5Stack CoreS3 feature enumeration
+ */
+typedef enum {
+    CORES3_POWER_MANAGER_FEATURE_LCD,      /*!< LCD display feature */
+    CORES3_POWER_MANAGER_FEATURE_TOUCH,    /*!< Touch screen feature */
+    CORES3_POWER_MANAGER_FEATURE_5V,       /*!< 5V feature */
+    CORES3_POWER_MANAGER_FEATURE_SD,       /*!< SD card feature */
+    CORES3_POWER_MANAGER_FEATURE_SPEAKER,  /*!< Speaker feature */
+    CORES3_POWER_MANAGER_FEATURE_CAMERA,   /*!< Camera feature */
+} cores3_power_manager_feature_t;
+
+/**
+ * @brief  Power manager handle structure
+ */
+typedef struct {
+    i2c_master_dev_handle_t pm_handle;  /*!< I2C device handle for AXP2101 PMU */
+} cores3_power_manager_handle_t;
+
+int cores3_power_manager_init(void *config, int cfg_size, void **device_handle);
+int cores3_power_manager_deinit(void *device_handle);
+esp_err_t cores3_power_manager_enable(void *device_handle, cores3_power_manager_feature_t feature);
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/application/basic_demo/boards/m5stack_cores3/sdkconfig.defaults.board
+++ b/application/basic_demo/boards/m5stack_cores3/sdkconfig.defaults.board
@@ -1,0 +1,22 @@
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# M5Stack CoreS3: 16 MB QIO flash @ 80 MHz
+CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+
+# M5Stack CoreS3: 8 MB quad PSRAM @ 80 MHz
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_QUAD=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# XIP from PSRAM requires octal PSRAM on ESP32-S3; disable for quad PSRAM.
+CONFIG_SPIRAM_XIP_FROM_PSRAM=n
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
+CONFIG_SPIRAM_RODATA=n
+
+# Quad PSRAM cannot keep the stack accessible while cache is disabled for a flash
+# transaction. Force FreeRTOS to allocate task stacks from internal RAM so claw
+# tasks tagged CLAW_TASK_STACK_PREFER_PSRAM fall back to internal memory.
+CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n
+

--- a/application/basic_demo/boards/m5stack_cores3/setup_device.c
+++ b/application/basic_demo/boards/m5stack_cores3/setup_device.c
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include <string.h>
+#include "esp_log.h"
+#include "esp_io_expander_aw9523b.h"
+#include "esp_lcd_ili9341.h"
+#include "esp_lcd_touch_ft5x06.h"
+
+static const char *TAG = "M5STACK_CORES3_SETUP_DEVICE";
+
+esp_err_t io_expander_factory_entry_t(i2c_master_bus_handle_t i2c_handle, const uint16_t dev_addr, esp_io_expander_handle_t *handle_ret)
+{
+    esp_err_t ret = esp_io_expander_new_aw9523b(i2c_handle, dev_addr, handle_ret);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create IO expander handle\n");
+        return ret;
+    }
+    /* P0 push-pull mode (GCR.bit4=1). Required so P0_x can drive high
+       (e.g. BUS_EN for Grove 5V output). */
+    uint8_t data = 0x10;
+    ret = esp_io_expander_aw9523b_write_reg(*handle_ret, AW9523B_REG_GCR, &data, 1);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set AW9523 P0 to push-pull mode");
+        return ret;
+    }
+    /* AW9523B power-on/soft-reset default is LED (constant-current) mode for
+       every pin. Switch P0/P1 fully into GPIO mode, otherwise high-level writes
+       only release the current sink (relying on external pull-ups) and cannot
+       drive enable signals like BUS_EN (P0_1) or BOOST_EN (P1_7). */
+    data = 0xFF;
+    ret = esp_io_expander_aw9523b_write_reg(*handle_ret, AW9523B_REG_LEDMODE0, &data, 1);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set AW9523 P0 to GPIO mode");
+        return ret;
+    }
+    data = 0xFF;
+    ret = esp_io_expander_aw9523b_write_reg(*handle_ret, AW9523B_REG_LEDMODE1, &data, 1);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set AW9523 P1 to GPIO mode");
+    }
+    return ret;
+}
+
+esp_err_t lcd_panel_factory_entry_t(esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel)
+{
+    esp_lcd_panel_dev_config_t panel_dev_cfg = {0};
+    memcpy(&panel_dev_cfg, panel_dev_config, sizeof(esp_lcd_panel_dev_config_t));
+    int ret = esp_lcd_new_panel_ili9341(io, &panel_dev_cfg, ret_panel);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "New ili9341 panel failed");
+    }
+    return ret;
+}
+
+esp_err_t lcd_touch_factory_entry_t(esp_lcd_panel_io_handle_t io, const esp_lcd_touch_config_t *touch_dev_config, esp_lcd_touch_handle_t *ret_touch)
+{
+    esp_err_t ret = esp_lcd_touch_new_i2c_ft5x06(io, touch_dev_config, ret_touch);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create ft5x06 touch driver: %s", esp_err_to_name(ret));
+    }
+    return ret;
+}


### PR DESCRIPTION
## Description

Add board support for the **M5Stack CoreS3** to `application/basic_demo`, so the demo can be built and flashed on CoreS3 out of the box:

```sh
idf.py gen-bmgr-config -c ./boards -b m5stack_cores3
idf.py build flash monitor
```

What's included under `application/basic_demo/boards/m5stack_cores3/`:

- **`board_info.yaml` / `board_peripherals.yaml` / `board_devices.yaml`** — esp_board_manager descriptors for the CoreS3:
  - I2C0 (SDA=12, SCL=11) for AXP2101, AW9523B, AW88298, ES7210, FT5x06
  - I2S0 48 kHz stereo (MCLK=0, BCLK=34, WS=33, DOUT=13, DIN=14)
  - SPI2 (MOSI=37, MISO=35, SCLK=36) for the ILI9341 LCD
  - GPIO46 for AW88298 PA enable
  - ILI9341 SPI panel (320×240, BGR, big-endian, color inverted)
  - FT5x06 I²C touch
  - AW9523B GPIO expander with the output mask CoreS3 needs (incl. `P0_1` BUS_EN and `P1_7` BOOST_EN for the Grove 5 V rail)

- **`power_manager.[ch]`** — custom AXP2101 power manager that brings up SD / Speaker / LCD / Touch / Grove 5 V in order, configures the AXP rails (ALDO1/2/3/4 and DLDO1 for the LCD backlight), and exposes `cores3_power_manager_enable()` for runtime control.

- **`setup_device.c`** — factory entries for the AW9523B expander, ILI9341 panel and FT5x06 touch. The expander setup programs `GCR=0x10` (P0 push-pull) **and** `LEDMODE0/1=0xFF` so every P0/P1 pin leaves the power-on LED constant-current mode and behaves as a real GPIO. Without this, `set_level(high)` only releases the current sink and cannot drive enables such as BUS_EN/BOOST_EN, so the Grove port stays at 0 V.

- **`components/esp_io_expander_aw9523b/`** — minimal AW9523B driver (16 IOs, push-pull / LED-mode register definitions, raw register-write helper) used by the board package.

- **`sdkconfig.defaults.board`**:
  - 16 MB QIO flash @ 80 MHz
  - 8 MB **Quad** PSRAM @ 80 MHz with `SPIRAM_XIP_FROM_PSRAM` / `FETCH_INSTRUCTIONS` / `RODATA` disabled (these are octal-only on ESP32-S3)
  - `CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n` so claw tasks tagged `CLAW_TASK_STACK_PREFER_PSRAM` fall back to internal RAM, avoiding the cache-disabled stack-sanity assert that Quad PSRAM triggers during SPI flash transactions.

## Related
<img width="595" height="78" alt="企业微信截图_7a37629c-7f90-4717-b798-fb9546eade9b" src="https://github.com/user-attachments/assets/a622cd94-4c20-4c89-a056-09467837384c" />
If you encounter this error, please consider performing the following steps.

```bash
idf.py add-dependency "espressif2022/esp_emote_gfx==3.0.2"
```

## Testing

Tested on physical M5Stack CoreS3 hardware:

- Build/flash/boot succeeds with the commands above.
- `esp_board_manager` enumerates and initializes all peripherals (AXP2101, AW9523B, AW88298, ES7210, ILI9341, FT5x06).
- AXP2101 rails come up in order; LCD backlight (DLDO1) turns on.
- After programming `GCR=0x10` + `LEDMODE0/1=0xFF` and asserting `P0_1` (BUS_EN) and `P1_7` (BOOST_EN), the Grove port outputs **5 V** (verified with multimeter); without the LED-mode write the rail stays at 0 V.
- FATFS mount, Wi-Fi STA/SoftAP, captive DNS, HTTP config server, event router and QQ chat messaging all work.
- Quad-PSRAM cache-disabled crash on FATFS reads from the event-router task is gone with `FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n`.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.