### PR TITLE
boards: Add LilyGO T-Display S3 board profile with I80 parallel display…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ managed_components/
 
 # Environment
 .env
+application/edge_agent/local_backup/
 # Cache / Compiled
 .cache
 *.pyc

--- a/application/edge_agent/tools/restore_espclaw_config.py
+++ b/application/edge_agent/tools/restore_espclaw_config.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import pathlib
+import sys
+
+import requests
+
+
+def load_json(path: pathlib.Path) -> dict:
+    with path.open("r", encoding="utf-8") as file_obj:
+        return json.load(file_obj)
+
+
+def main() -> int:
+    default_config_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "local_backup"
+        / "espclaw_config_latest.json"
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Restore ESPCLAW /api/config from a JSON backup"
+    )
+    parser.add_argument(
+        "--device",
+        default="http://localhost",
+        help="Device base URL (e.g., http://192.168.0.100)",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(default_config_path),
+        help="Path to config backup JSON",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print keys that would be updated",
+    )
+    args = parser.parse_args()
+
+    cfg_path = pathlib.Path(args.config)
+    if not cfg_path.exists():
+        print(f"Config file not found: {cfg_path}")
+        return 1
+
+    new_cfg = load_json(cfg_path)
+    base = args.device.rstrip("/")
+
+    try:
+        current = requests.get(f"{base}/api/config", timeout=10).json()
+    except Exception as exc:
+        print(f"Failed to read current config from device: {exc}")
+        return 1
+
+    merged = dict(current)
+    merged.update(new_cfg)
+
+    changed_keys = [
+        key for key in merged.keys() if merged.get(key) != current.get(key)
+    ]
+    print("Changed keys:", ", ".join(sorted(changed_keys)) if changed_keys else "(none)")
+
+    if args.dry_run:
+        print("Dry run only. No changes sent.")
+        return 0
+
+    try:
+        response = requests.post(f"{base}/api/config", json=merged, timeout=15)
+        print("POST /api/config status:", response.status_code)
+        print(response.text)
+        if response.status_code != 200:
+            return 1
+    except Exception as exc:
+        print(f"Failed to write config to device: {exc}")
+        return 1
+
+    print("Config restore sent. Reboot device to apply core changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/components/common/emote/CMakeLists.txt
+++ b/components/common/emote/CMakeLists.txt
@@ -13,7 +13,14 @@ idf_component_register(
 if(CONFIG_APP_CLAW_ENABLE_EMOTE)
     set(EMOTE_ASSETS_EXTERNAL_PATH "${CMAKE_CURRENT_LIST_DIR}/assets_local")
     set(EMOTE_ASSETS_FILE "${CMAKE_BINARY_DIR}/emote_assets.bin")
-    build_speaker_assets_bin("emote" "284_240" ${EMOTE_ASSETS_FILE} ${CONFIG_MMAP_FILE_NAME_LENGTH} ${EMOTE_ASSETS_EXTERNAL_PATH})
-    message(STATUS "Generated emote assets: ${EMOTE_ASSETS_FILE} -> emote partition")
+
+    if(CONFIG_ESP_BOARD_LILYGO_T_DISPLAY_S3)
+        set(EMOTE_ASSET_LAYOUT "320_170")
+    else()
+        set(EMOTE_ASSET_LAYOUT "284_240")
+    endif()
+
+    build_speaker_assets_bin("emote" "${EMOTE_ASSET_LAYOUT}" ${EMOTE_ASSETS_FILE} ${CONFIG_MMAP_FILE_NAME_LENGTH} ${EMOTE_ASSETS_EXTERNAL_PATH})
+    message(STATUS "Generated emote assets (${EMOTE_ASSET_LAYOUT}): ${EMOTE_ASSETS_FILE} -> emote partition")
     esptool_py_flash_to_partition(flash "emote" "${EMOTE_ASSETS_FILE}")
 endif()

--- a/components/common/emote/assets_local/320_170/config.json
+++ b/components/common/emote/assets_local/320_170/config.json
@@ -1,0 +1,3 @@
+{
+    "emoji_collection": "emoji_large"
+}

--- a/components/common/emote/assets_local/320_170/emote.json
+++ b/components/common/emote/assets_local/320_170/emote.json
@@ -1,0 +1,4 @@
+[
+    {"emote": "swim",        "src": "swim.eaf",     "loop": true,  "fps": 20},
+    {"emote": "offline",     "src": "offline.eaf",  "loop": true,  "fps": 20}
+]

--- a/components/common/emote/assets_local/320_170/layout.json
+++ b/components/common/emote/assets_local/320_170/layout.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "anim",
+    "name": "eye_anim",
+    "align": "GFX_ALIGN_CENTER",
+    "x": 0,
+    "y": 0,
+    "anim": {
+      "mirror": "false"
+    }
+  },
+  {
+    "type": "anim",
+    "name": "emerg_dlg",
+    "align": "GFX_ALIGN_CENTER",
+    "x": 0,
+    "y": 0,
+    "anim": {
+      "mirror": "false"
+    }
+  },
+  {
+    "type": "image",
+    "name": "status_icon",
+    "align": "GFX_ALIGN_TOP_LEFT",
+    "x": 5,
+    "y": 5
+  },
+  {
+    "type": "label",
+    "name": "toast_label",
+    "align": "GFX_ALIGN_TOP_MID",
+    "x": 0,
+    "y": 6,
+    "width": 280,
+    "height": 30,
+    "label": {
+      "color": 16777215,
+      "text_align": "GFX_TEXT_ALIGN_CENTER",
+      "long_mode": {
+        "type": "GFX_LABEL_LONG_SCROLL",
+        "loop": true,
+        "speed": 24
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Description

This PR updates the LilyGO T-Display S3 contribution to match the current upstream layout.

### What changed
- Add a 320x170 emote asset set for LilyGO T-Display S3 displays.
- Select the 320x170 emote layout when the LilyGO T-Display S3 board configuration is enabled.
- Add a small utility to restore saved device configuration through `/api/config`.
- Ignore local backup files used by that restore workflow.

### Why
Upstream `master` already contains the LilyGO T-Display S3 board definition in the current app layout. The remaining gap for this contribution is the display-sized emote asset set plus the configuration restore helper and local backup ignore rule.

### Validation
- Rebuilt the branch on top of `upstream/master`
- No merge conflicts with the base branch
- CLA check passed
- Tested on LilyGO T-Display S3 hardware with the 320x170 display layout