### PR TITLE
Add unified OTA capability for edge_agent (SD + HTTP)

### DIFF
--- a/application/edge_agent/main/CMakeLists.txt
+++ b/application/edge_agent/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(main_requires
     app_claw
     app_config
+    app_ota
     captive_dns
     http_server
     wifi_manager

--- a/application/edge_agent/main/idf_component.yml
+++ b/application/edge_agent/main/idf_component.yml
@@ -24,6 +24,9 @@ dependencies:
   app_config:
     path: ../components/app_config
 
+  app_ota:
+    path: ../../../components/common/app_ota
+
   cap_im_wechat:
     path: ../../../components/claw_capabilities/cap_im_wechat
     rules:

--- a/application/edge_agent/main/main.c
+++ b/application/edge_agent/main/main.c
@@ -19,6 +19,7 @@
 #include "esp_board_manager_includes.h"
 #include "captive_dns.h"
 #include "cmd_wifi.h"
+#include "app_ota.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #if CONFIG_APP_CLAW_CAP_IM_WECHAT
@@ -325,7 +326,24 @@ void app_main(void)
     init_timezone(app_config_get_timezone(s_config)); // no need to check error
     ESP_ERROR_CHECK(esp_board_manager_init());
     ESP_ERROR_CHECK(app_claw_ui_start());
+#if CONFIG_APP_OTA_FS_ENABLE && CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT && CONFIG_APP_OTA_FS_RUN_AT_BOOT
+    {
+        esp_err_t ota_sd_err =
+            app_ota_fs_boot_flow_at(CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH);
+        if (ota_sd_err != ESP_OK) {
+            ESP_LOGW(TAG, "SD FS OTA: %s", esp_err_to_name(ota_sd_err));
+        }
+    }
+#endif
     ESP_ERROR_CHECK(init_fatfs());
+#if CONFIG_APP_OTA_FS_ENABLE
+    {
+        esp_err_t ota_fs_err = app_ota_fs_boot_flow();
+        if (ota_fs_err != ESP_OK) {
+            ESP_LOGW(TAG, "FS OTA: %s", esp_err_to_name(ota_fs_err));
+        }
+    }
+#endif
     ESP_ERROR_CHECK(wifi_manager_init());
     ESP_ERROR_CHECK(http_server_init(&(http_server_config_t) {
         .storage_base_path = app_fatfs_base_path,
@@ -376,6 +394,15 @@ void app_main(void)
                  status.ap_ssid,
                  status.ap_ip,
                  status.ap_ip);
+    }
+
+    {
+        wifi_manager_status_t wm_ota = {0};
+        wifi_manager_get_status(&wm_ota);
+        esp_err_t ota_err = app_ota_http_boot_flow(wm_ota.sta_connected);
+        if (ota_err != ESP_OK) {
+            ESP_LOGW(TAG, "OTA bootstrap: %s", esp_err_to_name(ota_err));
+        }
     }
 
     ESP_ERROR_CHECK(app_claw_init_storage_paths(s_claw_paths));

--- a/application/edge_agent/partitions_8MB.csv
+++ b/application/edge_agent/partitions_8MB.csv
@@ -2,6 +2,9 @@
 nvs,       data, nvs,     0x9000,   0x6000
 otadata,   data, ota,     0xF000,   0x2000
 phy_init,  data, phy,     0x11000,  0x1000
-ota_0,     app,  ota_0,         ,   3M
-emote,     data, spiffs,        ,   3M
-storage,   data, fat,           ,  1500K
+# OTA slots slightly larger than 2560K for edge_agent ~0x288210 (tools/ota_sdcard_hil builds fat claw).
+# Keep total app+emote+storage = 8064K like older layout; shrink emote when HIL disables APP_CLAW_ENABLE_EMOTE (see ota_sdcard_hil.py overlay).
+ota_0,     app,  ota_0,         ,   2624K
+ota_1,     app,  ota_1,         ,   2624K
+emote,     data, spiffs,        ,   1792K
+storage,   data, fat,           ,   1024K

--- a/application/edge_agent/sdkconfig.defaults
+++ b/application/edge_agent/sdkconfig.defaults
@@ -1,6 +1,8 @@
 # This file was generated using idf.py save-defconfig. It can be edited manually.
 # Espressif IoT Development Framework (ESP-IDF) 5.5.1 Project Minimal Configuration
 #
+# Match on-module flash and partitions_8MB.csv (overrides board_manager 2MB default for HIL / fresh sdkconfig)
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_8MB.csv"
 CONFIG_HTTPD_WS_SUPPORT=y

--- a/components/common/app_claw/app_claw_cli.c
+++ b/components/common/app_claw/app_claw_cli.c
@@ -740,6 +740,7 @@ esp_err_t app_claw_cli_start(void)
 {
     esp_console_repl_t *repl = NULL;
     esp_console_repl_config_t repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
+    esp_err_t err = ESP_OK;
 
     ESP_LOGI(TAG, "Starting console REPL");
 
@@ -749,18 +750,22 @@ esp_err_t app_claw_cli_start(void)
 
 #if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
     esp_console_dev_uart_config_t hw_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_console_new_repl_uart(&hw_config, &repl_config, &repl));
+    err = esp_console_new_repl_uart(&hw_config, &repl_config, &repl);
 #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     esp_console_dev_usb_serial_jtag_config_t hw_config =
         ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&hw_config, &repl_config, &repl));
+    err = esp_console_new_repl_usb_serial_jtag(&hw_config, &repl_config, &repl);
 #elif CONFIG_ESP_CONSOLE_USB_CDC
     esp_console_dev_usb_cdc_config_t hw_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&hw_config, &repl_config, &repl));
+    err = esp_console_new_repl_usb_cdc(&hw_config, &repl_config, &repl);
 #else
     ESP_LOGE(TAG, "No supported console backend is enabled");
     return ESP_ERR_NOT_SUPPORTED;
 #endif
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Create REPL failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     esp_console_register_help_command();
     register_cap_cli_commands();
@@ -771,7 +776,11 @@ esp_err_t app_claw_cli_start(void)
             .help = "Submit a multi-turn prompt using the current session: ask <prompt>",
             .func = cmd_ask,
         };
-        ESP_ERROR_CHECK(esp_console_cmd_register(&ask_cmd));
+        err = esp_console_cmd_register(&ask_cmd);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Register 'ask' failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
 
     {
@@ -780,7 +789,11 @@ esp_err_t app_claw_cli_start(void)
             .help = "Submit a single-turn prompt without session history: ask_once <prompt>",
             .func = cmd_ask_once,
         };
-        ESP_ERROR_CHECK(esp_console_cmd_register(&ask_once_cmd));
+        err = esp_console_cmd_register(&ask_once_cmd);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Register 'ask_once' failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
 
     {
@@ -789,7 +802,11 @@ esp_err_t app_claw_cli_start(void)
             .help = "Show or switch the current session: session [id]",
             .func = cmd_session,
         };
-        ESP_ERROR_CHECK(esp_console_cmd_register(&session_cmd));
+        err = esp_console_cmd_register(&session_cmd);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Register 'session' failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
 
     {
@@ -798,7 +815,11 @@ esp_err_t app_claw_cli_start(void)
             .help = "cap operations: cap <list|call|groups|enable|disable|unload|load> ...",
             .func = cmd_cap,
         };
-        ESP_ERROR_CHECK(esp_console_cmd_register(&cap_cmd));
+        err = esp_console_cmd_register(&cap_cmd);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Register 'cap' failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
 
     {
@@ -807,7 +828,11 @@ esp_err_t app_claw_cli_start(void)
             .help = "Automation operations: auto <reload|rules|rule|add_rule|update_rule|delete_rule|last|emit_message|emit_trigger> ...",
             .func = cmd_auto,
         };
-        ESP_ERROR_CHECK(esp_console_cmd_register(&auto_cmd));
+        err = esp_console_cmd_register(&auto_cmd);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Register 'auto' failed: %s", esp_err_to_name(err));
+            return err;
+        }
     }
 
     printf("Type 'help', 'auto rules', 'auto last', or 'auto emit_message qq_gateway qq 123 hello'\n");

--- a/components/common/app_ota/CMakeLists.txt
+++ b/components/common/app_ota/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(
+    SRCS
+        "app_ota.c"
+    INCLUDE_DIRS
+        "include"
+    REQUIRES
+        esp_ota_service
+)

--- a/components/common/app_ota/Kconfig
+++ b/components/common/app_ota/Kconfig
@@ -1,0 +1,94 @@
+menu "App OTA (esp_ota_service)"
+
+    menu "HTTP OTA bootstrap"
+
+        config APP_OTA_HTTP_ENABLE
+            bool "Enable optional HTTP firmware OTA bootstrap"
+            default n
+            help
+                When enabled and manifest/firmware URLs are non-empty (menuconfig below),
+                the device runs one HTTP OTA check after Wi‑Fi STA is connected during boot.
+
+        if APP_OTA_HTTP_ENABLE
+
+            config APP_OTA_HTTP_RUN_AT_BOOT
+                bool "Run HTTP OTA check once at startup (after STA online)"
+                default y
+
+            config APP_OTA_HTTP_MANIFEST_URL
+                string "Firmware manifest JSON URL (http/https)"
+                default ""
+                help
+                    JSON manifest consumed by esp_ota_service_checker_manifest (version, optional sha256, size).
+
+            config APP_OTA_HTTP_FIRMWARE_URL
+                string "Firmware binary URL (must match manifest server)"
+                default ""
+                help
+                    Absolute URL for the downloadable app image (paired with APP_OTA_HTTP_MANIFEST_URL).
+
+            config APP_OTA_HTTP_CHUNK_TIMEOUT_MS
+                int "HTTP read timeout per chunk (milliseconds)"
+                default 30000
+                range 3000 120000
+
+        endif # APP_OTA_HTTP_ENABLE
+
+    endmenu
+
+    menu "Filesystem OTA bootstrap"
+
+        config APP_OTA_FS_ENABLE
+            bool "Enable optional filesystem (VFS) app OTA bootstrap"
+            default y
+            help
+                After SPI flash FAT mounts (typically /fatfs), read a staged edge_agent.bin from an absolute path
+                using esp_ota_service_source_fs. Runs **before Wi-Fi**. File must expose a higher semver than running
+                image when APP_OTA_FS_REQUIRE_NEWER_SEMVER=y.
+
+        if APP_OTA_FS_ENABLE
+
+            config APP_OTA_FS_RUN_AT_BOOT
+                bool "Run FS OTA when candidate file exists at boot"
+                default y
+
+            config APP_OTA_FS_FIRMWARE_ABS_PATH
+                string "Absolute filesystem path (VFS fopen) for app binary"
+                default "/fatfs/ota/firmware.bin"
+                help
+                    Typical layout: mkdir /fatfs/ota via host mount and drop edge_agent.bin renamed to firmware.bin.
+
+            config APP_OTA_FS_TRY_SDCARD_AT_BOOT
+                bool "Before SPI flash FAT, try app OTA from SD (board_manager fs_sdcard)"
+                default n
+                help
+                    After esp_board_manager_init(), if the board exposes fs_sdcard (usually mounted at /sdcard),
+                    probe APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH for a newer app image.
+                    Matches esp_ota_service tools/sdcard_writer output name firmware.bin.
+                    Use together with tools/ota_sdcard_hil.py and ota_fs_flash_sdcard.py from ADF.
+
+            config APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH
+                string "Absolute path on SD mount for app binary"
+                default "/sdcard/firmware.bin"
+                depends on APP_OTA_FS_TRY_SDCARD_AT_BOOT
+                help
+                    Default matches sdcard_writer (components/esp_ota_service/tools/sdcard_writer).
+
+            config APP_OTA_FS_READ_BUF_BYTES
+                int "Read buffer chunk size passed to filesystem source"
+                default 4096
+                range 512 8192
+
+            config APP_OTA_FS_REQUIRE_NEWER_SEMVER
+                bool "Reject candidate whose esp_app_desc_t version is not strictly higher"
+                default y
+
+            config APP_OTA_FS_CHECK_PROJECT_NAME
+                bool "Reject candidate when esp_app_desc_t project_name differs from running firmware"
+                default y
+
+        endif # APP_OTA_FS_ENABLE
+
+    endmenu
+
+endmenu

--- a/components/common/app_ota/README.md
+++ b/components/common/app_ota/README.md
@@ -1,0 +1,134 @@
+# app_ota Usage Guide
+
+`app_ota` is an application OTA component built on top of `espressif/esp_ota_service`.
+It provides two boot-time upgrade paths:
+
+- HTTP OTA: after STA is connected, pull firmware via manifest + firmware URL.
+- Filesystem OTA: at boot, read firmware from an absolute local path (for example `/fatfs/ota/firmware.bin` or `/sdcard/firmware.bin`).
+
+Component dependency is declared in `idf_component.yml`:
+
+- `espressif/esp_ota_service: "*"`
+
+## 1. Public API
+
+Header: `include/app_ota.h`
+
+- `app_ota_fs_boot_flow_at(const char *firmware_abs_path)`
+  - Run one FS OTA attempt using a specific absolute path (for example `/sdcard/firmware.bin`).
+- `app_ota_fs_boot_flow(void)`
+  - Run one FS OTA attempt using `CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH`.
+- `app_ota_http_boot_flow(bool sta_station_connected_to_ap)`
+  - Handle rollback pending-verify status, then run one HTTP OTA attempt when config is valid.
+
+Note: on successful upgrade the device reboots. With rollback enabled, confirm/rollback depends on network state.
+
+## 2. Menuconfig Options
+
+Path: `Component config -> App OTA (esp_ota_service)`
+
+### HTTP OTA Key Options
+
+- `CONFIG_APP_OTA_HTTP_ENABLE`
+- `CONFIG_APP_OTA_HTTP_RUN_AT_BOOT`
+- `CONFIG_APP_OTA_HTTP_MANIFEST_URL`
+- `CONFIG_APP_OTA_HTTP_FIRMWARE_URL`
+- `CONFIG_APP_OTA_HTTP_CHUNK_TIMEOUT_MS`
+
+Notes:
+
+- HTTP OTA runs only when `ENABLE=y` and both URLs are non-empty.
+- Version comparison is handled by manifest checker and requires candidate version > running version.
+
+### Filesystem OTA Key Options
+
+- `CONFIG_APP_OTA_FS_ENABLE`
+- `CONFIG_APP_OTA_FS_RUN_AT_BOOT`
+- `CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH` (default `/fatfs/ota/firmware.bin`)
+- `CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT`
+- `CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH` (default `/sdcard/firmware.bin`)
+- `CONFIG_APP_OTA_FS_READ_BUF_BYTES`
+- `CONFIG_APP_OTA_FS_REQUIRE_NEWER_SEMVER`
+- `CONFIG_APP_OTA_FS_CHECK_PROJECT_NAME`
+
+## 3. Recommended Integration Order
+
+Reference call sequence in `application/edge_agent/main/main.c`:
+
+1. After `esp_board_manager_init()`, if SD-first path is enabled, call
+   `app_ota_fs_boot_flow_at(CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH)`.
+2. After `init_fatfs()`, call `app_ota_fs_boot_flow()` for SPI FAT path.
+3. After Wi-Fi starts and STA status is known, call `app_ota_http_boot_flow(sta_connected)`.
+
+This implements a "local-media first, network OTA second" strategy.
+
+## 4. HTTP OTA Manifest
+
+Manifest should include at least:
+
+- `version` (semver string, for example `1.2.3`)
+- `project_name` (optional check)
+- `size` (firmware size)
+- `sha256` (optional but recommended)
+
+Firmware URL must point to downloadable app binary (for example `edge_agent.bin`).
+
+## 5. SDCard OTA Preparation
+
+For SD boot OTA, make sure:
+
+- Upgrade firmware has been manually copied to SD card and named `firmware.bin` at `/sdcard/firmware.bin` (or match your configured path).
+- `CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT=y`.
+- Configured path matches actual mount/path on target.
+
+## 6. Manual Step-by-Step Validation
+
+### 6.1 SDCard OTA (Manual)
+
+1. Build upgrade firmware (higher semver)
+   - Set `version.txt` to upgrade version (for example `1.2.4`), then:
+   - `idf.py -B build_sd_upgrade build`
+   - Output: `build_sd_upgrade/edge_agent.bin`
+2. Manually copy upgrade firmware to SD card
+   - Copy `build_sd_upgrade/edge_agent.bin` to SD card and rename it to `firmware.bin`.
+   - Ensure it is accessible by `CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH` (default `/sdcard/firmware.bin`).
+3. Build and flash baseline firmware (lower semver)
+   - Set `version.txt` to baseline version (for example `1.2.3`), then:
+   - `idf.py -B build_sd_base build flash -p /dev/ttyUSB3`
+   - For first-time verification, it is recommended to run
+     `idf.py -B build_sd_base erase-flash -p /dev/ttyUSB3` once.
+4. Check serial logs
+   - Look for: SD firmware detected, OTA starts, `OTA finished`, reboot, and upgraded version string.
+
+### 6.2 HTTP OTA (Using esp_ota_service tools, Manual)
+
+1. Build upgrade firmware (higher semver)
+   - Set `version.txt` to upgrade version (for example `1.2.4`):
+   - `idf.py -B build_http_upgrade build`
+   - Output: `build_http_upgrade/edge_agent.bin`
+2. Prepare `firmware_samples` in `esp_ota_service/tools`
+   - Directory: `application/edge_agent/managed_components/espressif__esp_ota_service/tools/firmware_samples`
+   - Copy firmware there, for example `edge_agent_v1.2.4.bin`
+   - Create/update `manifest.json` with at least `version`, `size`, `sha256`, and `url`
+3. Start HTTP server with OTA service tool script
+   - Script: `ota_http_serve.py`
+   - Example:
+     ```bash
+     python3 application/edge_agent/managed_components/espressif__esp_ota_service/tools/ota_http_serve.py \
+       --bin edge_agent_v1.2.4.bin \
+       --port 18070 \
+       --update-manifest-url
+     ```
+4. Build and flash baseline firmware (lower semver)
+   - Set `version.txt` to baseline version (for example `1.2.3`)
+   - In menuconfig/sdconfig set:
+     - `CONFIG_APP_OTA_HTTP_ENABLE=y`
+     - `CONFIG_APP_OTA_HTTP_RUN_AT_BOOT=y`
+     - `CONFIG_APP_OTA_HTTP_MANIFEST_URL=http://<HOST_IP>:18070/manifest.json`
+     - `CONFIG_APP_OTA_HTTP_FIRMWARE_URL=http://<HOST_IP>:18070/firmware.bin`
+   - Then run: `idf.py -B build_http_base build flash -p /dev/ttyUSB3`
+5. Check serial logs
+   - Look for: HTTP download succeeds, version check passes, `OTA finished`, reboot, and upgraded version.
+
+Tip: `erase-flash` is optional, but recommended for first-time verification or when switching configs to reduce NVS state interference.
+

--- a/components/common/app_ota/README_CN.md
+++ b/components/common/app_ota/README_CN.md
@@ -1,0 +1,131 @@
+# app_ota 使用说明
+
+`app_ota` 是一个基于 `espressif/esp_ota_service` 的应用 OTA 组件，提供两条启动期升级链路：
+
+- HTTP OTA：设备连上 STA 后，从 manifest + firmware URL 拉取升级包。
+- Filesystem OTA：设备启动时从本地文件系统绝对路径读取固件（如 `/fatfs/ota/firmware.bin` 或 `/sdcard/firmware.bin`）。
+
+组件依赖在 `idf_component.yml` 中声明：
+
+- `espressif/esp_ota_service: "*"`
+
+## 1. 对外 API
+
+头文件：`include/app_ota.h`
+
+- `app_ota_fs_boot_flow_at(const char *firmware_abs_path)`
+  - 使用指定绝对路径执行一次 FS OTA（例如 `/sdcard/firmware.bin`）。
+- `app_ota_fs_boot_flow(void)`
+  - 使用 `CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH` 执行一次 FS OTA。
+- `app_ota_http_boot_flow(bool sta_station_connected_to_ap)`
+  - 处理 rollback pending-verify，并在 HTTP OTA 配置满足时执行一次 HTTP OTA。
+
+注意：升级成功后设备会重启；开启 rollback 时，会根据联网状态执行确认或回滚。
+
+## 2. Menuconfig 配置
+
+路径：`Component config -> App OTA (esp_ota_service)`
+
+### HTTP OTA 关键项
+
+- `CONFIG_APP_OTA_HTTP_ENABLE`
+- `CONFIG_APP_OTA_HTTP_RUN_AT_BOOT`
+- `CONFIG_APP_OTA_HTTP_MANIFEST_URL`
+- `CONFIG_APP_OTA_HTTP_FIRMWARE_URL`
+- `CONFIG_APP_OTA_HTTP_CHUNK_TIMEOUT_MS`
+
+说明：
+
+- 只有在 `ENABLE=y` 且 URL 非空时，HTTP OTA 才会执行。
+- 版本比较由 manifest checker 完成，要求候选版本高于当前运行版本。
+
+### Filesystem OTA 关键项
+
+- `CONFIG_APP_OTA_FS_ENABLE`
+- `CONFIG_APP_OTA_FS_RUN_AT_BOOT`
+- `CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH`（默认 `/fatfs/ota/firmware.bin`）
+- `CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT`
+- `CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH`（默认 `/sdcard/firmware.bin`）
+- `CONFIG_APP_OTA_FS_READ_BUF_BYTES`
+- `CONFIG_APP_OTA_FS_REQUIRE_NEWER_SEMVER`
+- `CONFIG_APP_OTA_FS_CHECK_PROJECT_NAME`
+
+## 3. 推荐接入顺序
+
+参考 `application/edge_agent/main/main.c` 的调用时序：
+
+1. `esp_board_manager_init()` 后，如启用 SD 卡优先启动链路，先调用
+   `app_ota_fs_boot_flow_at(CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH)`。
+2. `init_fatfs()` 后调用 `app_ota_fs_boot_flow()`，检查 SPI FAT 路径升级包。
+3. Wi-Fi 启动并获取 STA 状态后，调用 `app_ota_http_boot_flow(sta_connected)`。
+
+这样可以实现“先本地介质，再网络 OTA”的启动升级策略。
+
+## 4. HTTP OTA 数据格式
+
+manifest 至少包含这些字段（与 `esp_ota_service_checker_manifest` 对齐）：
+
+- `version`：语义版本字符串，例如 `1.2.3`
+- `project_name`：项目名（可选校验）
+- `size`：固件大小
+- `sha256`：固件哈希（可选但建议提供）
+
+firmware URL 指向可下载的应用二进制（例如 `edge_agent.bin`）。
+
+## 5. SDCard OTA 准备
+
+若使用 SD 卡启动 OTA，请确保：
+
+- 已将升级固件手动拷贝到 SD 卡，并命名为 `firmware.bin`，路径为 `/sdcard/firmware.bin`（或与配置路径一致）。
+- `CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT=y`。
+- 路径配置与实际挂载点一致。
+
+## 6. 人工分步验证
+
+### 6.1 SDCard OTA（人工分步）
+
+1. 编译升级版本固件（higher semver）
+   - 修改 `version.txt` 为升级版本（例如 `1.2.4`），然后：
+   - `idf.py -B build_sd_upgrade build`
+   - 产物：`build_sd_upgrade/edge_agent.bin`
+2. 手动拷贝升级包到 SD 卡
+   - 将 `build_sd_upgrade/edge_agent.bin` 拷贝到 SD 卡，并重命名为 `firmware.bin`。
+   - 确保设备启动后可从 `CONFIG_APP_OTA_FS_SDCARD_FIRMWARE_ABS_PATH` 访问到该文件（默认 `/sdcard/firmware.bin`）。
+3. 编译并刷入基线版本固件（lower semver）
+   - 修改 `version.txt` 为基线版本（例如 `1.2.3`），然后：
+   - `idf.py -B build_sd_base build flash -p /dev/ttyUSB3`
+   - 首次验证建议先执行一次 `idf.py -B build_sd_base erase-flash -p /dev/ttyUSB3`。
+4. 观察串口日志
+   - 重点检查：检测到 SD 卡固件、开始 OTA、`OTA finished`、重启后版本变为升级版本。
+
+### 6.2 HTTP OTA（使用 esp_ota_service tools 手动分步）
+
+1. 编译升级版本固件（higher semver）
+   - 修改 `version.txt` 为升级版本（例如 `1.2.4`）：
+   - `idf.py -B build_http_upgrade build`
+   - 产物：`build_http_upgrade/edge_agent.bin`
+2. 准备 `esp_ota_service/tools` 的 `firmware_samples`
+   - 目录：`application/edge_agent/managed_components/espressif__esp_ota_service/tools/firmware_samples`
+   - 复制升级固件到该目录，例如命名为 `edge_agent_v1.2.4.bin`
+   - 生成/更新 `manifest.json`，至少包含 `version`、`size`、`sha256`、`url`
+3. 启动 HTTP 文件服务（使用 ota_service 自带脚本）
+   - 脚本：`ota_http_serve.py`
+   - 示例命令：
+     ```bash
+     python3 application/edge_agent/managed_components/espressif__esp_ota_service/tools/ota_http_serve.py \
+       --bin edge_agent_v1.2.4.bin \
+       --port 18070 \
+       --update-manifest-url
+     ```
+4. 编译并刷入基线版本固件（lower semver）
+   - 修改 `version.txt` 为基线版本（例如 `1.2.3`）
+   - 在 menuconfig/sdconfig 中配置：
+     - `CONFIG_APP_OTA_HTTP_ENABLE=y`
+     - `CONFIG_APP_OTA_HTTP_RUN_AT_BOOT=y`
+     - `CONFIG_APP_OTA_HTTP_MANIFEST_URL=http://<HOST_IP>:18070/manifest.json`
+     - `CONFIG_APP_OTA_HTTP_FIRMWARE_URL=http://<HOST_IP>:18070/firmware.bin`
+   - 然后执行：`idf.py -B build_http_base build flash -p /dev/ttyUSB3`
+5. 观察串口日志
+   - 重点检查：HTTP 拉取成功、版本检查通过、`OTA finished`、重启后版本升级。
+
+提示：`erase-flash` 不是必需步骤，但首次验证或切换配置场景建议执行，以减少 NVS 历史状态干扰。

--- a/components/common/app_ota/app_ota.c
+++ b/components/common/app_ota/app_ota.c
@@ -1,0 +1,484 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_ota.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <sys/stat.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+#include "adf_event_hub.h"
+#include "esp_app_desc.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_service.h"
+#include "esp_system.h"
+#include "esp_ota_service.h"
+#include "esp_ota_service_checker_app.h"
+#include "esp_ota_service_checker_manifest.h"
+#include "esp_ota_service_source_fs.h"
+#include "esp_ota_service_source_http.h"
+#include "esp_ota_service_target_app.h"
+#include "esp_ota_service_verifier_sha256.h"
+
+#include "sdkconfig.h"
+
+static const char APP_OTA_TAG[] = "app_ota";
+
+#define APP_OTA_EVT_DONE_BIT  ((EventBits_t)BIT0)
+#define APP_OTA_EVT_FAIL_BIT  ((EventBits_t)BIT1)
+#define APP_OTA_EVT_SKIP_BIT  ((EventBits_t)BIT2)
+
+#define APP_OTA_SESSION_WAIT_MS  (600000U)
+
+#if CONFIG_APP_OTA_HTTP_ENABLE || CONFIG_APP_OTA_FS_ENABLE
+
+typedef struct {
+    EventGroupHandle_t eg;
+    char               channel[6];
+} app_ota_evt_ctx_t;
+
+static void app_ota_service_on_adf_event(const adf_event_t *event, void *handler_ctx)
+{
+    app_ota_evt_ctx_t *evc = (app_ota_evt_ctx_t *)handler_ctx;
+    if (event == NULL || event->payload == NULL || event->payload_len < sizeof(esp_ota_service_event_t) || evc == NULL ||
+        evc->eg == NULL) {
+        return;
+    }
+    const esp_ota_service_event_t *evt = (const esp_ota_service_event_t *)event->payload;
+
+    switch (evt->id) {
+        case ESP_OTA_SERVICE_EVT_SESSION_BEGIN:
+            ESP_LOGI(APP_OTA_TAG, "[%s] session started", evc->channel);
+            break;
+        case ESP_OTA_SERVICE_EVT_ITEM_VER_CHECK:
+            if (evt->error == ESP_OK && !evt->ver_check.upgrade_available) {
+                ESP_LOGW(APP_OTA_TAG, "[%s] version check: no upgrade (skip)", evc->channel);
+                xEventGroupSetBits(evc->eg, APP_OTA_EVT_SKIP_BIT);
+            } else {
+                ESP_LOGI(APP_OTA_TAG, "[%s] version check err=%s upgrade=%d size=%" PRIu32, evc->channel,
+                         esp_err_to_name(evt->error), evt->ver_check.upgrade_available ? 1 : 0, evt->ver_check.image_size);
+            }
+            break;
+        case ESP_OTA_SERVICE_EVT_ITEM_BEGIN:
+            ESP_LOGI(APP_OTA_TAG, "[%s] transfer started", evc->channel);
+            break;
+        case ESP_OTA_SERVICE_EVT_ITEM_PROGRESS:
+            ESP_LOGD(APP_OTA_TAG, "[%s] progress %" PRIu32 "/%" PRIu32, evc->channel, evt->progress.bytes_written,
+                     evt->progress.total_bytes);
+            break;
+        case ESP_OTA_SERVICE_EVT_ITEM_END:
+            if (evt->item_end.status == ESP_OTA_SERVICE_ITEM_STATUS_OK) {
+                ESP_LOGI(APP_OTA_TAG, "[%s] item finished OK", evc->channel);
+            } else if (evt->item_end.status == ESP_OTA_SERVICE_ITEM_STATUS_SKIPPED) {
+                ESP_LOGW(APP_OTA_TAG, "[%s] item skipped reason=%d", evc->channel, (int)evt->item_end.reason);
+                xEventGroupSetBits(evc->eg, APP_OTA_EVT_SKIP_BIT);
+            } else {
+                ESP_LOGE(APP_OTA_TAG, "[%s] item failed %s reason=%d", evc->channel, esp_err_to_name(evt->error),
+                         (int)evt->item_end.reason);
+                xEventGroupSetBits(evc->eg, APP_OTA_EVT_FAIL_BIT);
+            }
+            break;
+        case ESP_OTA_SERVICE_EVT_SESSION_END:
+            if (evt->session_end.aborted || evt->session_end.failed_count > 0) {
+                xEventGroupSetBits(evc->eg, APP_OTA_EVT_DONE_BIT | APP_OTA_EVT_FAIL_BIT);
+            } else {
+                xEventGroupSetBits(evc->eg, APP_OTA_EVT_DONE_BIT);
+            }
+            break;
+        case ESP_OTA_SERVICE_EVT_MAX:
+            break;
+        default:
+            break;
+    }
+}
+
+static esp_err_t app_ota_attach_event_observer(esp_ota_service_t *svc, EventGroupHandle_t eg, app_ota_evt_ctx_t *ctx,
+                                               const char *channel)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->eg = eg;
+    strlcpy(ctx->channel, channel, sizeof(ctx->channel));
+
+    adf_event_subscribe_info_t sub = ADF_EVENT_SUBSCRIBE_INFO_DEFAULT();
+    sub.handler = app_ota_service_on_adf_event;
+    sub.handler_ctx = ctx;
+    return esp_service_event_subscribe((esp_service_t *)svc, &sub);
+}
+
+static esp_err_t app_ota_session_start_wait_and_finish(esp_ota_service_t *svc, EventGroupHandle_t eg, const char *channel,
+                                                       const char *resource_for_log)
+{
+    ESP_LOGI(APP_OTA_TAG, "[%s] starting OTA resource=%s", channel, resource_for_log);
+
+    esp_err_t ret = esp_service_start((esp_service_t *)svc);
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[%s] esp_service_start failed: %s", channel, esp_err_to_name(ret));
+        esp_ota_service_destroy(svc);
+        vEventGroupDelete(eg);
+        return ret;
+    }
+
+    EventBits_t bits = xEventGroupWaitBits(eg, APP_OTA_EVT_DONE_BIT | APP_OTA_EVT_FAIL_BIT | APP_OTA_EVT_SKIP_BIT,
+                                           pdFALSE, pdFALSE, pdMS_TO_TICKS(APP_OTA_SESSION_WAIT_MS));
+
+    esp_err_t out = ESP_OK;
+    if (bits & APP_OTA_EVT_SKIP_BIT) {
+        out = ESP_OK;
+    } else if ((bits & APP_OTA_EVT_DONE_BIT) && !(bits & APP_OTA_EVT_FAIL_BIT)) {
+        esp_ota_service_destroy(svc);
+        vEventGroupDelete(eg);
+        ESP_LOGW(APP_OTA_TAG, "[%s] OTA finished — rebooting", channel);
+        vTaskDelay(pdMS_TO_TICKS(500));
+        esp_restart();
+    } else if (bits & APP_OTA_EVT_FAIL_BIT) {
+        out = ESP_FAIL;
+        ESP_LOGE(APP_OTA_TAG, "[%s] session reported failure", channel);
+    } else {
+        out = ESP_ERR_TIMEOUT;
+        ESP_LOGE(APP_OTA_TAG, "[%s] session timed out", channel);
+    }
+
+    esp_ota_service_destroy(svc);
+    vEventGroupDelete(eg);
+    return out;
+}
+
+#endif /* CONFIG_APP_OTA_HTTP_ENABLE || CONFIG_APP_OTA_FS_ENABLE */
+
+static void app_ota_handle_pending_verify(bool sta_station_connected_to_ap)
+{
+#if CONFIG_OTA_ENABLE_ROLLBACK
+    bool pending = false;
+    esp_err_t err = esp_ota_service_is_pending_verify(&pending);
+    if (err != ESP_OK) {
+        ESP_LOGW(APP_OTA_TAG, "pending verify probe failed: %s", esp_err_to_name(err));
+        return;
+    }
+    if (!pending) {
+        return;
+    }
+
+    if (sta_station_connected_to_ap) {
+        ESP_LOGI(APP_OTA_TAG, "pending verify — confirming (STA online)");
+        err = esp_ota_service_confirm_update();
+        if (err != ESP_OK) {
+            ESP_LOGE(APP_OTA_TAG, "confirm_update failed: %s", esp_err_to_name(err));
+            (void)esp_ota_service_rollback();
+        }
+    } else {
+        ESP_LOGW(APP_OTA_TAG, "pending verify but STA offline — rolling back");
+        (void)esp_ota_service_rollback();
+    }
+#else
+    (void)sta_station_connected_to_ap;
+#endif
+}
+
+#if CONFIG_APP_OTA_HTTP_ENABLE
+
+static bool app_ota_manifest_and_firmware_urls_ok(void)
+{
+    return CONFIG_APP_OTA_HTTP_MANIFEST_URL[0] != '\0' && CONFIG_APP_OTA_HTTP_FIRMWARE_URL[0] != '\0';
+}
+
+static esp_err_t app_ota_run_http_manifest_session_once(void)
+{
+    esp_err_t ret;
+    esp_ota_service_cfg_t svc_cfg = ESP_OTA_SERVICE_CFG_DEFAULT();
+    esp_ota_service_t *svc = NULL;
+    ret = esp_ota_service_create(&svc_cfg, &svc);
+    if (ret != ESP_OK || svc == NULL) {
+        ESP_LOGE(APP_OTA_TAG, "[http] esp_ota_service_create failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    EventGroupHandle_t ota_evt = xEventGroupCreate();
+    if (ota_evt == NULL) {
+        esp_ota_service_destroy(svc);
+        return ESP_ERR_NO_MEM;
+    }
+
+    app_ota_evt_ctx_t ev_ctx;
+    ret = app_ota_attach_event_observer(svc, ota_evt, &ev_ctx, "http");
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[http] subscribe failed: %s", esp_err_to_name(ret));
+        vEventGroupDelete(ota_evt);
+        esp_ota_service_destroy(svc);
+        return ret;
+    }
+
+    esp_ota_service_source_http_cfg_t hcfg = {
+        .timeout_ms = CONFIG_APP_OTA_HTTP_CHUNK_TIMEOUT_MS,
+        .buf_size = 4096,
+    };
+
+    const esp_app_desc_t *app_desc = esp_app_get_description();
+    esp_ota_service_checker_manifest_cfg_t mcfg = {
+        .manifest_uri = CONFIG_APP_OTA_HTTP_MANIFEST_URL,
+        .current_version = app_desc->version,
+        .require_higher_version = true,
+        .check_project_name = false,
+    };
+
+    esp_ota_service_checker_t *manifest_chk = esp_ota_service_checker_manifest_create(&mcfg);
+    if (manifest_chk == NULL) {
+        ESP_LOGE(APP_OTA_TAG, "[http] manifest checker create failed");
+        vEventGroupDelete(ota_evt);
+        esp_ota_service_destroy(svc);
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_ota_service_check_result_t chk_result;
+    memset(&chk_result, 0, sizeof(chk_result));
+    esp_err_t cr = manifest_chk->check(manifest_chk, NULL, NULL, &chk_result);
+    manifest_chk->destroy(manifest_chk);
+    if (cr != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[http] manifest check failed: %s", esp_err_to_name(cr));
+        vEventGroupDelete(ota_evt);
+        esp_ota_service_destroy(svc);
+        return cr;
+    }
+    if (!chk_result.upgrade_available) {
+        ESP_LOGI(APP_OTA_TAG, "[http] running '%s' up to date (server '%s')", app_desc->version, chk_result.version);
+        vEventGroupDelete(ota_evt);
+        esp_ota_service_destroy(svc);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(APP_OTA_TAG, "[http] upgrade available '%s' -> '%s'", app_desc->version, chk_result.version);
+
+    esp_ota_service_verifier_t *ver = NULL;
+    if (chk_result.has_hash) {
+        esp_ota_service_verifier_sha256_cfg_t vcfg;
+        memcpy(vcfg.expected_hash, chk_result.hash, sizeof(vcfg.expected_hash));
+        esp_err_t vr = esp_ota_service_verifier_sha256_create(&vcfg, &ver);
+        if (vr != ESP_OK) {
+            ESP_LOGW(APP_OTA_TAG, "[http] SHA256 verifier create failed (%s) — proceeding without integrity check",
+                     esp_err_to_name(vr));
+        }
+    } else {
+        ESP_LOGW(APP_OTA_TAG, "[http] manifest has no sha256 — integrity skipped");
+    }
+
+    esp_ota_service_source_t *src = NULL;
+    esp_ota_service_target_t *tgt = NULL;
+    ret = esp_ota_service_source_http_create(&hcfg, &src);
+    if (ret == ESP_OK) {
+        esp_ota_service_target_app_cfg_t app_cfg = {.bulk_flash_erase = true};
+        ret = esp_ota_service_target_app_create(&app_cfg, &tgt);
+    }
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[http] source/target create failed: %s", esp_err_to_name(ret));
+        if (src != NULL && src->destroy != NULL) {
+            src->destroy(src);
+        }
+        if (tgt != NULL && tgt->destroy != NULL) {
+            tgt->destroy(tgt);
+        }
+        if (ver != NULL && ver->destroy != NULL) {
+            ver->destroy(ver);
+        }
+        vEventGroupDelete(ota_evt);
+        esp_ota_service_destroy(svc);
+        return ret;
+    }
+
+    esp_ota_upgrade_item_t items[] = {{
+        .uri = CONFIG_APP_OTA_HTTP_FIRMWARE_URL,
+        .partition_label = NULL,
+        .source = src,
+        .target = tgt,
+        .verifier = ver,
+        .checker = NULL,
+        .skip_on_fail = false,
+        .resumable = CONFIG_OTA_ENABLE_RESUME ? true : false,
+    }};
+
+    ret = esp_ota_service_set_upgrade_list(svc, items, sizeof(items) / sizeof(items[0]));
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[http] esp_ota_service_set_upgrade_list failed: %s", esp_err_to_name(ret));
+        esp_ota_service_destroy(svc);
+        vEventGroupDelete(ota_evt);
+        return ret;
+    }
+
+    return app_ota_session_start_wait_and_finish(svc, ota_evt, "http", CONFIG_APP_OTA_HTTP_FIRMWARE_URL);
+}
+
+#endif /* CONFIG_APP_OTA_HTTP_ENABLE */
+
+#if CONFIG_APP_OTA_FS_ENABLE
+
+static esp_err_t app_ota_run_fs_upgrade_once(const char *abs_path_vfs)
+{
+    esp_ota_service_cfg_t svc_cfg = ESP_OTA_SERVICE_CFG_DEFAULT();
+    esp_ota_service_t *svc = NULL;
+    esp_err_t ret = esp_ota_service_create(&svc_cfg, &svc);
+    if (ret != ESP_OK || svc == NULL) {
+        ESP_LOGE(APP_OTA_TAG, "[fs] esp_ota_service_create failed %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    EventGroupHandle_t eg = xEventGroupCreate();
+    if (eg == NULL) {
+        esp_ota_service_destroy(svc);
+        return ESP_ERR_NO_MEM;
+    }
+
+    app_ota_evt_ctx_t ev_ctx;
+    ret = app_ota_attach_event_observer(svc, eg, &ev_ctx, "fs");
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[fs] subscribe failed %s", esp_err_to_name(ret));
+        vEventGroupDelete(eg);
+        esp_ota_service_destroy(svc);
+        return ret;
+    }
+
+    esp_ota_service_checker_app_cfg_t checker_cfg = {
+        .version_policy =
+            {
+                .require_higher_version = CONFIG_APP_OTA_FS_REQUIRE_NEWER_SEMVER ? true : false,
+                .check_project_name = CONFIG_APP_OTA_FS_CHECK_PROJECT_NAME ? true : false,
+            },
+        .should_upgrade = NULL,
+        .should_upgrade_ctx = NULL,
+    };
+
+    esp_ota_service_checker_t *checker = esp_ota_service_checker_app_create(&checker_cfg);
+    if (checker == NULL) {
+        vEventGroupDelete(eg);
+        esp_ota_service_destroy(svc);
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_ota_service_source_fs_cfg_t sf_cfg = {
+        .buf_size = CONFIG_APP_OTA_FS_READ_BUF_BYTES,
+    };
+    esp_ota_service_source_t *src = NULL;
+    esp_ota_service_target_t *tgt = NULL;
+    ret = esp_ota_service_source_fs_create(&sf_cfg, &src);
+    if (ret == ESP_OK) {
+        esp_ota_service_target_app_cfg_t tgt_cfg = {.bulk_flash_erase = true};
+        ret = esp_ota_service_target_app_create(&tgt_cfg, &tgt);
+    }
+    if (ret != ESP_OK || src == NULL || tgt == NULL) {
+        ESP_LOGE(APP_OTA_TAG, "[fs] source/target alloc failed %s", esp_err_to_name(ret));
+        if (checker->destroy != NULL) {
+            checker->destroy(checker);
+        }
+        if (src != NULL && src->destroy != NULL) {
+            src->destroy(src);
+        }
+        if (tgt != NULL && tgt->destroy != NULL) {
+            tgt->destroy(tgt);
+        }
+        vEventGroupDelete(eg);
+        esp_ota_service_destroy(svc);
+        return ret != ESP_OK ? ret : ESP_ERR_NO_MEM;
+    }
+
+    esp_ota_upgrade_item_t items[] = {{
+        .uri = abs_path_vfs,
+        .partition_label = NULL,
+        .source = src,
+        .target = tgt,
+        .verifier = NULL,
+        .checker = checker,
+        .skip_on_fail = false,
+        .resumable = CONFIG_OTA_ENABLE_RESUME ? true : false,
+    }};
+
+    ret = esp_ota_service_set_upgrade_list(svc, items, sizeof(items) / sizeof(items[0]));
+    if (ret != ESP_OK) {
+        ESP_LOGE(APP_OTA_TAG, "[fs] set_upgrade_list failed %s", esp_err_to_name(ret));
+        esp_ota_service_destroy(svc);
+        vEventGroupDelete(eg);
+        return ret;
+    }
+
+    return app_ota_session_start_wait_and_finish(svc, eg, "fs", abs_path_vfs);
+}
+
+static esp_err_t app_ota_fs_boot_flow_at_impl(const char *path)
+{
+#if CONFIG_APP_OTA_FS_RUN_AT_BOOT
+    if (path == NULL || path[0] != '/') {
+        ESP_LOGW(APP_OTA_TAG, "[fs] invalid firmware path (need absolute VFS path)");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct stat st = {0};
+    if (stat(path, &st) != 0 || !S_ISREG(st.st_mode)) {
+        ESP_LOGD(APP_OTA_TAG, "[fs] no candidate at %s", path);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(APP_OTA_TAG, "[fs] boot_flow firmware stat ok size=%ld path=%s", (long)st.st_size, path);
+    esp_err_t err = app_ota_run_fs_upgrade_once(path);
+    if (err != ESP_OK) {
+        ESP_LOGW(APP_OTA_TAG, "[fs] OTA aborted: %s", esp_err_to_name(err));
+    }
+    return err;
+#else
+    (void)path;
+    return ESP_OK;
+#endif
+}
+
+#endif /* CONFIG_APP_OTA_FS_ENABLE */
+
+esp_err_t app_ota_fs_boot_flow_at(const char *firmware_abs_path)
+{
+#if CONFIG_APP_OTA_FS_ENABLE
+    return app_ota_fs_boot_flow_at_impl(firmware_abs_path);
+#else
+    (void)firmware_abs_path;
+    return ESP_OK;
+#endif
+}
+
+esp_err_t app_ota_fs_boot_flow(void)
+{
+#if CONFIG_APP_OTA_FS_ENABLE && CONFIG_APP_OTA_FS_RUN_AT_BOOT
+    return app_ota_fs_boot_flow_at_impl(CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH);
+#else
+    return ESP_OK;
+#endif
+}
+
+esp_err_t app_ota_http_boot_flow(bool sta_station_connected_to_ap)
+{
+    ESP_LOGI(APP_OTA_TAG, "[http] boot_flow entry sta_online=%d", sta_station_connected_to_ap ? 1 : 0);
+    app_ota_handle_pending_verify(sta_station_connected_to_ap);
+
+#if CONFIG_APP_OTA_HTTP_ENABLE && CONFIG_APP_OTA_HTTP_RUN_AT_BOOT
+    if (!sta_station_connected_to_ap || !app_ota_manifest_and_firmware_urls_ok()) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(APP_OTA_TAG, "[http] manifest + firmware URLs configured — starting bootstrap");
+
+    esp_err_t err = app_ota_run_http_manifest_session_once();
+    if (err != ESP_OK) {
+        ESP_LOGW(APP_OTA_TAG, "[http] bootstrap finished with errors: %s", esp_err_to_name(err));
+    }
+    return err;
+
+#elif CONFIG_APP_OTA_HTTP_ENABLE
+    (void)sta_station_connected_to_ap;
+    return ESP_OK;
+#else
+    (void)sta_station_connected_to_ap;
+    return ESP_OK;
+#endif
+}

--- a/components/common/app_ota/idf_component.yml
+++ b/components/common/app_ota/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/esp_ota_service: "*"

--- a/components/common/app_ota/include/app_ota.h
+++ b/components/common/app_ota/include/app_ota.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Runs after Wi-Fi manager has settled (STA/AP). When rollback is enabled, confirms or rolls back a
+ * pending-verify boot; when HTTP OTA is enabled and URLs are set, may start a manifest-driven session.
+ *
+ * @param sta_station_connected_to_ap Whether STA has associated and has usable IP context (for confirm vs rollback).
+ */
+esp_err_t app_ota_http_boot_flow(bool sta_station_connected_to_ap);
+
+/**
+ * After FATFS (e.g. /fatfs) is mounted, optionally streams app firmware from a VFS path (typically
+ * CONFIG_APP_OTA_FS_FIRMWARE_ABS_PATH) via esp_ota_service_source_fs. May reboot without returning.
+ */
+esp_err_t app_ota_fs_boot_flow(void);
+
+/**
+ * Same as app_ota_fs_boot_flow() but uses an explicit absolute VFS path (e.g. /sdcard/firmware.bin).
+ * Used for SD-staged images before SPI flash FAT is mounted when CONFIG_APP_OTA_FS_TRY_SDCARD_AT_BOOT is enabled.
+ */
+esp_err_t app_ota_fs_boot_flow_at(const char *firmware_abs_path);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Background
This change introduces a unified OTA capability in `edge_agent`, covering both SD-card and HTTP update paths.

## Changes
- Add new `app_ota` component for OTA orchestration.
- Integrate OTA boot flow in `edge_agent` startup.
- Support OTA from SD (`/sdcard/firmware.bin`) and HTTP manifest/firmware endpoints.
- Update project wiring (component deps, build/config, partition-related settings) required by OTA integration.
- Add component-level docs for OTA usage and configuration.

## Validation
- SD OTA path: firmware discovery, version check, and update/skip behavior verified.
- HTTP OTA path: manifest/firmware fetch and version-based decision flow verified.
- Expected reject behavior confirmed when incoming version is not higher than current version.