### PR TITLE
feat(mcp): MCP Client Streamable HTTP 支持及会话健壮性改进

### DIFF
--- a/components/claw_capabilities/cap_mcp_client/CHANGELOG.md
+++ b/components/claw_capabilities/cap_mcp_client/CHANGELOG.md
@@ -1,0 +1,52 @@
+# MCP Client 改动记录
+
+## 2026-05-05 — Streamable HTTP 支持 + Session 管理修复
+
+### 背景
+MCP Client 之前通过 `mcp/$smart` 端点连接 MCPHub，但存在 session ID 提取失败导致 `tools/list` 返回 HTTP 400 的问题。经调试发现根因是响应头 `mcp-session-id` 全小写，代码用驼峰 `Mcp-Session-Id` 比较。
+
+### 修改列表
+
+#### `src/cap_mcp_client_core.c`
+
+| 改动 | 说明 |
+|------|------|
+| **Session 提取修复** | `HTTP_EVENT_ON_HEADER` 中加小写 `"mcp-session-id"` 匹配，服务器返回 header 是全小写 |
+| **SSE 解析简化** | 去掉双循环计数+合并逻辑，改用单 `data:` 行直接提取 JSON，避免堆元数据破坏导致 `tlsf_free` 断言崩溃 |
+| **ON_FINISH 空终止** | 在 `HTTP_EVENT_ON_FINISH` 中加 `buf->data[buf->len] = '\0'` 兜底 |
+| **perform 后空终止** | `esp_http_client_perform` 返回后显式空终止，双重保险 |
+| **响应缓冲区 8KB→64KB** | MCPHub 统一端点 `/mcp` 返回 37KB+ 工具列表，原 8KB 严重不足 |
+| **日志分级** | `[HEADER]`/`[REQ]`/`[RESP]Body`/`[RPC]`/`[SSE]JSON` 降级为 `ESP_LOGD`；保留 `[SESSION]`/`[INIT]`/`[LIST]`/HTTP status 为 `ESP_LOGI` |
+
+#### `src/cap_mcp_client_internal.h`
+
+| 改动 | 说明 |
+|------|------|
+| **默认端点** | `CAP_MCP_DEFAULT_ENDPOINT` 从 `"mcp_server"` 改为 `"mcp"`，匹配 MCPHub 标准端点 |
+
+#### `src/cap_mcp_client.c`
+
+| 改动 | 说明 |
+|------|------|
+| **Schema 补全 description** | `mcp_list_tools` 和 `mcp_call_tool` 的 `input_schema_json` 每个属性加 `description` 字段，LLM 能理解参数含义 |
+| **工具描述增强** | `.description` 补充使用示例，如 `"Pass server_url (e.g. http://host:port) and optionally auth_token..."` |
+
+#### `app_capabilities.c`（在 `components/common/app_claw/`）
+
+| 改动 | 说明 |
+|------|------|
+| **LLM 可见性** | `cap_mcp_client` 组 `llm_visible` 从 `false` 改为 `true`，DeepSeek 才能看到这三个工具 |
+
+### 协议层改动
+
+| 协议 | 之前 | 之后 |
+|------|------|------|
+| 端点 | `POST /mcp/$smart`（智能路由） | `POST /mcp`（MCPHub 统一端点） |
+| Session | 响应头 `Mcp-Session-Id`（驼峰，不匹配） | `mcp-session-id`（小写，匹配） |
+| 缓冲区 | 8KB（截断 37KB 响应） | 64KB（完整接收） |
+| 传输 | Streamable HTTP（已支持） | 不变，SSE/JSON 自动检测 |
+
+### 遗留问题
+
+- `tools/call` 在 MCPHub 统一端点 `/mcp` 下需要通过工具名前缀匹配服务器，形如 `网页抓取-firecrawl_scrape`
+- 也可走 `/mcp/{server}` 端点直接选服务器

--- a/components/claw_capabilities/cap_mcp_client/CMakeLists.txt
+++ b/components/claw_capabilities/cap_mcp_client/CMakeLists.txt
@@ -2,6 +2,7 @@ idf_component_register(
     SRCS
         "src/cap_mcp_client.c"
         "src/cap_mcp_client_core.c"
+        "src/cap_mcp_client_sse.c"
         "src/cap_mcp_discover_core.c"
         "src/cmd_cap_mcp_client.c"
     INCLUDE_DIRS

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client.c
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client.c
@@ -13,6 +13,84 @@
 
 #include "cap_mcp_client_internal.h"
 
+/**
+ * @brief Truncate string at a UTF-8 character boundary.
+ * If buf[max_len-1] falls in the middle of a multi-byte sequence,
+ * back up to the start of that character to avoid invalid code points.
+ */
+static void cap_mcp_truncate_utf8_safe(char *buf, size_t max_len)
+{
+    if (!buf || max_len == 0) return;
+    size_t len = strlen(buf);
+    if (len < max_len) return;
+
+    /* Start from the truncation point and back up to a valid leading byte */
+    size_t pos = max_len - 1;
+    while (pos > 0 && (buf[pos] & 0xC0) == 0x80) {
+        pos--;  /* Skip continuation bytes (10xxxxxx) */
+    }
+    /* pos now points at the leading byte of the last complete character */
+    /* But if we backed up too far, just truncate cleanly */
+    if (pos < max_len - 4 && pos > 0) {
+        buf[pos] = '\0';
+    } else {
+        buf[max_len - 1] = '\0';
+    }
+}
+
+/**
+ * @brief Sanitize a string in-place: replace invalid UTF-8 bytes with spaces.
+ * Scans for bytes that don't form valid multi-byte sequences and replaces them.
+ */
+static void cap_mcp_sanitize_utf8(char *buf)
+{
+    if (!buf) return;
+    size_t src = 0, dst = 0;
+    while (buf[src]) {
+        unsigned char c = (unsigned char)buf[src];
+        if (c < 0x80) {
+            /* Single byte (0x00-0x7F): valid ASCII */
+            buf[dst++] = buf[src++];
+        } else if (c >= 0xC2 && c <= 0xDF) {
+            /* 2-byte sequence: check continuation byte */
+            if (buf[src+1] && ((unsigned char)buf[src+1] & 0xC0) == 0x80) {
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+            } else {
+                buf[dst++] = ' '; src++; /* Replace invalid lead */
+            }
+        } else if (c >= 0xE0 && c <= 0xEF) {
+            /* 3-byte sequence: check 2 continuation bytes */
+            if (buf[src+1] && buf[src+2] &&
+                ((unsigned char)buf[src+1] & 0xC0) == 0x80 &&
+                ((unsigned char)buf[src+2] & 0xC0) == 0x80) {
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+            } else {
+                buf[dst++] = ' '; src++; /* Replace invalid lead */
+            }
+        } else if (c >= 0xF0 && c <= 0xF4) {
+            /* 4-byte sequence: check 3 continuation bytes */
+            if (buf[src+1] && buf[src+2] && buf[src+3] &&
+                ((unsigned char)buf[src+1] & 0xC0) == 0x80 &&
+                ((unsigned char)buf[src+2] & 0xC0) == 0x80 &&
+                ((unsigned char)buf[src+3] & 0xC0) == 0x80) {
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+                buf[dst++] = buf[src++];
+            } else {
+                buf[dst++] = ' '; src++; /* Replace invalid lead */
+            }
+        } else {
+            /* Invalid byte (0x80-0xBF continuation without lead, or 0xC0-0xC1 overlong) */
+            buf[dst++] = ' '; src++;
+        }
+    }
+    buf[dst] = '\0';
+}
+
 static esp_err_t cap_mcp_client_group_init(void)
 {
     esp_err_t err = mdns_init();
@@ -69,6 +147,7 @@ static void cap_mcp_extract_content_text(const cJSON *content,
     }
 
     output[offset] = '\0';
+    cap_mcp_sanitize_utf8(output);
 }
 
 static esp_err_t cap_mcp_call_execute(const char *input_json,
@@ -106,6 +185,7 @@ static esp_err_t cap_mcp_call_execute(const char *input_json,
         }
     }
 
+    cap_mcp_sanitize_utf8(output);
     cJSON_Delete(result);
     return ESP_OK;
 }
@@ -139,20 +219,47 @@ static esp_err_t cap_mcp_list_execute(const char *input_json,
 
     tools_array = cJSON_GetObjectItem(result, "tools");
     if (cJSON_IsArray(tools_array)) {
+        size_t count = 0;
+        size_t max_display = 0;
+        cJSON_ArrayForEach(tool, tools_array) {
+            count++;
+        }
+        
+        /* Write summary line */
+        int written = snprintf(output + offset, output_size - offset,
+                               "Found %u tool(s) on the remote MCP server.\n\n", (unsigned)count);
+        if (written > 0 && (size_t)written < output_size - offset) offset += (size_t)written;
+        
+        /* List tool names (compact, no descriptions) */
         cJSON_ArrayForEach(tool, tools_array) {
             const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(tool, "name"));
-            const char *description = cJSON_GetStringValue(cJSON_GetObjectItem(tool, "description"));
-            int written = snprintf(output + offset,
-                                   output_size - offset,
-                                   "- %s: %s\n",
-                                   name ? name : "(no name)",
-                                   description ? description : "");
-
-            if (written < 0 || (size_t)written >= output_size - offset) {
-                offset = output_size - 1;
+            size_t name_len = name ? strlen(name) : 9; /* "(no name)" */
+            size_t line_len = 2 + name_len + 1; /* "  " + name + "\n" */
+            
+            /* Check if full line fits without truncation */
+            if (line_len >= output_size - offset) {
+                if (count > max_display) {
+                    offset += snprintf(output + offset, output_size - offset,
+                                       "...and %u more\n", (unsigned)(count - max_display));
+                }
                 break;
             }
-            offset += (size_t)written;
+            /* Reserve min 10 bytes at end for safety */
+            if (output_size - offset - line_len < 10) {
+                if (count > max_display) {
+                    offset += snprintf(output + offset, output_size - offset,
+                                       "...and %u more\n", (unsigned)(count - max_display));
+                }
+                break;
+            }
+            
+            memcpy(output + offset, "  ", 2);
+            offset += 2;
+            memcpy(output + offset, name, name_len);
+            offset += name_len;
+            output[offset] = '\n';
+            offset += 1;
+            max_display++;
         }
     }
 
@@ -166,9 +273,10 @@ static esp_err_t cap_mcp_list_execute(const char *input_json,
     if (offset == 0) {
         snprintf(output, output_size, "(no tools)");
     } else if (offset >= output_size) {
-        output[output_size - 1] = '\0';
+        cap_mcp_truncate_utf8_safe(output, output_size);
     }
 
+    cap_mcp_sanitize_utf8(output);
     cJSON_Delete(result);
     return ESP_OK;
 }
@@ -236,29 +344,57 @@ static const claw_cap_descriptor_t s_mcp_client_descriptors[] = {
         .id = "mcp_list_tools",
         .name = "mcp_list_tools",
         .family = "mcp",
-        .description = "List tools from a remote MCP server.",
+        .description = "List tools from a remote MCP server. "
+                       "Pass server_url (e.g. http://host:port) and optionally "
+                       "auth_token for Bearer-authenticated servers. "
+                       "The endpoint defaults to 'mcp' for standard MCPHub.",
         .kind = CLAW_CAP_KIND_CALLABLE,
         .cap_flags = CLAW_CAP_FLAG_CALLABLE_BY_LLM,
         .input_schema_json =
-        "{\"type\":\"object\",\"properties\":{\"server_url\":{\"type\":\"string\"},\"endpoint\":{\"type\":\"string\"},\"cursor\":{\"type\":\"string\"}},\"required\":[\"server_url\"]}",
+        "{"
+          "\"type\":\"object\","
+          "\"properties\":{"
+            "\"server_url\":{\"type\":\"string\",\"description\":\"Remote MCP server URL, e.g. http://cloud.yujj.top:3000\"},"
+            "\"endpoint\":{\"type\":\"string\",\"description\":\"Endpoint path (default: 'mcp' for MCPHub)\"},"
+            "\"auth_token\":{\"type\":\"string\",\"description\":\"Bearer token for authentication\"},"
+            "\"initialize\":{\"type\":\"boolean\",\"description\":\"Force re-initialization handshake\"},"
+            "\"cursor\":{\"type\":\"string\",\"description\":\"Pagination cursor\"},"
+            "\"transport\":{\"type\":\"string\",\"enum\":[\"http\",\"sse\"],\"description\":\"Transport (default: http)\"}"
+          "},"
+          "\"required\":[\"server_url\"]"
+        "}",
         .execute = cap_mcp_list_execute,
     },
     {
         .id = "mcp_call_tool",
         .name = "mcp_call_tool",
         .family = "mcp",
-        .description = "Call a tool on a remote MCP server.",
+        .description = "Call a tool on a remote MCP server. "
+                       "Requires server_url, tool_name, and arguments as JSON object. "
+                       "Pass auth_token for authenticated servers.",
         .kind = CLAW_CAP_KIND_CALLABLE,
         .cap_flags = CLAW_CAP_FLAG_CALLABLE_BY_LLM,
         .input_schema_json =
-        "{\"type\":\"object\",\"properties\":{\"server_url\":{\"type\":\"string\"},\"endpoint\":{\"type\":\"string\"},\"tool_name\":{\"type\":\"string\"},\"arguments\":{\"type\":\"object\"}},\"required\":[\"server_url\",\"tool_name\"]}",
+        "{"
+          "\"type\":\"object\","
+          "\"properties\":{"
+            "\"server_url\":{\"type\":\"string\",\"description\":\"Remote MCP server URL, e.g. http://cloud.yujj.top:3000\"},"
+            "\"endpoint\":{\"type\":\"string\",\"description\":\"Endpoint path (default: 'mcp' for MCPHub)\"},"
+            "\"tool_name\":{\"type\":\"string\",\"description\":\"Tool name to call\"},"
+            "\"arguments\":{\"type\":\"object\",\"description\":\"JSON arguments for the tool\"},"
+            "\"auth_token\":{\"type\":\"string\",\"description\":\"Bearer token for authentication\"},"
+            "\"initialize\":{\"type\":\"boolean\",\"description\":\"Force re-initialization handshake\"},"
+            "\"transport\":{\"type\":\"string\",\"enum\":[\"http\",\"sse\"],\"description\":\"Transport (default: http)\"}"
+          "},"
+          "\"required\":[\"server_url\",\"tool_name\"]"
+        "}",
         .execute = cap_mcp_call_execute,
     },
     {
         .id = "mcp_discover",
         .name = "mcp_discover",
         .family = "mcp",
-        .description = "Discover MCP servers advertised on the local network.",
+        .description = "Discover MCP servers on the local network via mDNS.",
         .kind = CLAW_CAP_KIND_CALLABLE,
         .cap_flags = CLAW_CAP_FLAG_CALLABLE_BY_LLM,
         .input_schema_json =

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_core.c
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_core.c
@@ -42,6 +42,7 @@ typedef struct {
     bool force_initialize;
     bool initialized;
     bool use_sse;                 /* Use SSE transport instead of HTTP POST */
+    int retry_count;              /* Used for one-time retry on session failure */
 } cap_mcp_request_opts_t;
 
 static cap_mcp_request_opts_t s_cached_opts = {0};
@@ -62,11 +63,16 @@ static esp_err_t cap_mcp_http_event_handler(esp_http_client_event_t *event)
         if (event->header_key && event->header_value) {
             ESP_LOGD(TAG, "[HEADER] %s: %s", event->header_key, event->header_value);
             
-            if (ctx->session_id && ctx->session_id_size > 0 &&
-                    (strcmp(event->header_key, "mcp-session-id") == 0 ||
-                     strcmp(event->header_key, "Mcp-Session-Id") == 0)) {
-                strlcpy(ctx->session_id, event->header_value, ctx->session_id_size);
-                ESP_LOGI(TAG, "[SESSION] Extracted Session ID: %s", event->header_value);
+            if (ctx->session_id && ctx->session_id_size > 0 && event->header_key) {
+                const char *k = event->header_key;
+                if (strcasecmp(k, "mcp-session-id") == 0 ||
+                    strcasecmp(k, "mcp-session") == 0 ||
+                    strcasecmp(k, "x-session-id") == 0 ||
+                    strcasecmp(k, "session-id") == 0 ||
+                    strcasecmp(k, "x-mcp-session") == 0) {
+                    strlcpy(ctx->session_id, event->header_value, ctx->session_id_size);
+                    ESP_LOGI(TAG, "[SESSION] Extracted %s: %s", k, event->header_value);
+                }
             }
         }
         return ESP_OK;
@@ -567,6 +573,12 @@ static esp_err_t cap_mcp_maybe_initialize_session(const char *full_url,
     } else {
         ESP_LOGW(TAG, "[INIT] No session ID received (response_session_id[0]=%d, has_cache=%d)",
                  response_session_id[0], cached_session_id ? 1 : 0);
+        /* Clear any existing cached session to avoid reusing stale session IDs */
+        if (cached_session_id && cached_session_id_size > 0) {
+            cached_session_id[0] = '\0';
+        }
+        /* Mark global cached opts as not initialized to force re-init next time */
+        s_cached_opts.initialized = false;
     }
 
     cJSON_Delete(response);
@@ -652,6 +664,9 @@ esp_err_t cap_mcp_list_remote_tools(const char *input_json, cJSON **result_out)
             return ESP_ERR_INVALID_ARG;
         }
 
+        ESP_LOGI(TAG, "[DIAG] Before init: initialized=%d, cached_session=%s, force_init=%d",
+                 s_cached_opts.initialized, s_cached_opts.session_id, force_initialize);
+
         if (force_initialize || !s_cached_opts.initialized || strcmp(s_cached_opts.session_id, "") == 0) {
             err = cap_mcp_maybe_initialize_session(full_url,
                                                    auth_token_buf,
@@ -694,10 +709,29 @@ esp_err_t cap_mcp_list_remote_tools(const char *input_json, cJSON **result_out)
     error_obj = cJSON_GetObjectItem(response, "error");
     if (cJSON_IsObject(error_obj)) {
         cJSON *message = cJSON_GetObjectItem(error_obj, "message");
+        const char *msg = cJSON_IsString(message) ? message->valuestring : "Unknown MCP error";
+
+        // Detect session-related errors and attempt a one-time recovery
+        if (strstr(msg, "No session") || strstr(msg, "not found") || strstr(msg, "SESSION ERROR") || strstr(msg, "No session ID")) {
+            ESP_LOGW(TAG, "[SESSION] Detected session error: %s", msg);
+            // Clear cache and mark uninitialized
+            s_cached_opts.session_id[0] = '\0';
+            s_cached_opts.initialized = false;
+
+            // Only retry once using retry_count to avoid recursion loop
+            if (s_cached_opts.retry_count == 0) {
+                s_cached_opts.retry_count = 1;
+                cJSON_Delete(response);
+                cJSON_Delete(root);
+                esp_err_t retry_err = cap_mcp_list_remote_tools(input_json, result_out);
+                s_cached_opts.retry_count = 0;
+                return retry_err;
+            }
+        }
 
         cJSON_AddStringToObject(root,
                                 "error_message",
-                                cJSON_IsString(message) ? message->valuestring : "Unknown MCP error");
+                                msg);
         cJSON_AddItemToObject(root, "tools", tools_out);
         cJSON_Delete(response);
         *result_out = root;

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_core.c
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_core.c
@@ -13,12 +13,16 @@
 #include "esp_http_client.h"
 #include "esp_log.h"
 
+#include "cap_mcp_client_sse.h"
+
 static const char *TAG = "mcp_client_core";
 
 #define CAP_MCP_REQUEST_ID_CALL    1
 #define CAP_MCP_REQUEST_ID_LIST    2
-#define CAP_MCP_RESPONSE_BUF_SIZE  (8 * 1024)
-#define CAP_MCP_HTTP_TIMEOUT_MS    20000
+#define CAP_MCP_REQUEST_ID_INIT    3
+#define CAP_MCP_RESPONSE_BUF_SIZE  (64 * 1024)
+#define CAP_MCP_HTTP_TIMEOUT_MS    5000
+#define CAP_MCP_SSE_RESPONSE_SIZE  4096
 
 typedef struct {
     char *data;
@@ -26,22 +30,79 @@ typedef struct {
     size_t cap;
 } cap_mcp_buf_t;
 
+typedef struct {
+    cap_mcp_buf_t *body;
+    char *session_id;
+    size_t session_id_size;
+} cap_mcp_http_ctx_t;
+
+typedef struct {
+    char auth_token[128];
+    char session_id[128];
+    bool force_initialize;
+    bool initialized;
+    bool use_sse;                 /* Use SSE transport instead of HTTP POST */
+} cap_mcp_request_opts_t;
+
+static cap_mcp_request_opts_t s_cached_opts = {0};
+
 static esp_err_t cap_mcp_http_event_handler(esp_http_client_event_t *event)
 {
-    cap_mcp_buf_t *buf = (cap_mcp_buf_t *)event->user_data;
+    cap_mcp_http_ctx_t *ctx = (cap_mcp_http_ctx_t *)event->user_data;
+    cap_mcp_buf_t *buf = ctx ? ctx->body : NULL;
     size_t needed;
 
-    if (!buf || event->event_id != HTTP_EVENT_ON_DATA) {
+    if (!ctx) {
         return ESP_OK;
     }
 
-    needed = buf->len + event->data_len;
-    if (needed < buf->cap) {
-        memcpy(buf->data + buf->len, event->data, event->data_len);
-        buf->len += event->data_len;
-        buf->data[buf->len] = '\0';
+    /* Log all events for debugging */
+    switch (event->event_id) {
+    case HTTP_EVENT_ON_HEADER:
+        if (event->header_key && event->header_value) {
+            ESP_LOGD(TAG, "[HEADER] %s: %s", event->header_key, event->header_value);
+            
+            if (ctx->session_id && ctx->session_id_size > 0 &&
+                    (strcmp(event->header_key, "mcp-session-id") == 0 ||
+                     strcmp(event->header_key, "Mcp-Session-Id") == 0)) {
+                strlcpy(ctx->session_id, event->header_value, ctx->session_id_size);
+                ESP_LOGI(TAG, "[SESSION] Extracted Session ID: %s", event->header_value);
+            }
+        }
+        return ESP_OK;
+    
+    case HTTP_EVENT_ON_DATA:
+        if (!buf) return ESP_OK;
+        needed = buf->len + event->data_len;
+        if (needed < buf->cap) {
+            memcpy(buf->data + buf->len, event->data, event->data_len);
+            buf->len += event->data_len;
+            buf->data[buf->len] = '\0';
+        } else {
+            ESP_LOGW(TAG, "[DATA] Buffer full: need=%u cap=%u, discarding %d bytes",
+                     (unsigned)needed, (unsigned)buf->cap, event->data_len);
+        }
+        return ESP_OK;
+    
+    case HTTP_EVENT_ERROR:
+        ESP_LOGW(TAG, "[ERROR] HTTP Event Error");
+        return ESP_OK;
+    
+    case HTTP_EVENT_ON_CONNECTED:
+        ESP_LOGD(TAG, "[CONNECT] Connected");
+        return ESP_OK;
+    
+    case HTTP_EVENT_ON_FINISH:
+        ESP_LOGD(TAG, "[FINISH] Finished");
+        if (buf && buf->data && buf->len < buf->cap) {
+            buf->data[buf->len] = '\0';
+        }
+        return ESP_OK;
+    
+    default:
+        ESP_LOGD(TAG, "[EVENT] Unhandled event %d", event->event_id);
+        return ESP_OK;
     }
-    return ESP_OK;
 }
 
 static void cap_mcp_build_full_url(const char *server_url,
@@ -73,39 +134,77 @@ static void cap_mcp_build_full_url(const char *server_url,
 
 static esp_err_t cap_mcp_http_post(const char *url,
                                    const char *body,
-                                   cap_mcp_buf_t *buf)
+                                   const char *auth_token,
+                                   const char *session_id,
+                                   cap_mcp_buf_t *buf,
+                                   char *response_session_id,
+                                   size_t response_session_id_size)
 {
-    esp_http_client_config_t config = {
-        .url = url,
-        .method = HTTP_METHOD_POST,
-        .event_handler = cap_mcp_http_event_handler,
-        .user_data = buf,
-        .timeout_ms = CAP_MCP_HTTP_TIMEOUT_MS,
-        .buffer_size = 2048,
-        .crt_bundle_attach = esp_crt_bundle_attach,
+    cap_mcp_http_ctx_t ctx = {
+        .body = buf,
+        .session_id = response_session_id,
+        .session_id_size = response_session_id_size,
     };
+    esp_http_client_config_t *cfg = calloc(1, sizeof(esp_http_client_config_t));
+    if (!cfg) return ESP_ERR_NO_MEM;
+    cfg->url = url;
+    cfg->method = HTTP_METHOD_POST;
+    cfg->event_handler = cap_mcp_http_event_handler;
+    cfg->user_data = &ctx;
+    cfg->timeout_ms = CAP_MCP_HTTP_TIMEOUT_MS;
+    cfg->buffer_size = 2048;
+    cfg->crt_bundle_attach = esp_crt_bundle_attach;
     esp_http_client_handle_t client = NULL;
     esp_err_t err;
     int status;
 
-    client = esp_http_client_init(&config);
+    client = esp_http_client_init(cfg);
+    free(cfg);
     if (!client) {
         return ESP_ERR_NO_MEM;
     }
 
     esp_http_client_set_header(client, "Content-Type", "application/json");
-    esp_http_client_set_header(client, "Accept", "application/json");
+    esp_http_client_set_header(client, "Accept", "application/json, text/event-stream");
+    if (auth_token && auth_token[0]) {
+        char bearer[160];
+
+        snprintf(bearer, sizeof(bearer), "Bearer %s", auth_token);
+        esp_http_client_set_header(client, "Authorization", bearer);
+    }
+    if (session_id && session_id[0]) {
+        esp_http_client_set_header(client, "Mcp-Session-Id", session_id);
+    }
     esp_http_client_set_post_field(client, body, (int)strlen(body));
+    
+    ESP_LOGD(TAG, "[REQ] URL=%s", url);
+    ESP_LOGD(TAG, "[REQ] Body (len=%u): %s", (unsigned)strlen(body), body);
+    
     err = esp_http_client_perform(client);
     status = esp_http_client_get_status_code(client);
+
+    if (buf && buf->data && buf->len < buf->cap) {
+        buf->data[buf->len] = '\0';
+    }
+
+    ESP_LOGI(TAG, "[RESP] HTTP status=%d, body_len=%u", status, (unsigned)buf->len);
+    ESP_LOGD(TAG, "[RESP] Body (first 256): %.*s", 256, buf->data && buf->len > 0 ? buf->data : "");
+    
     esp_http_client_cleanup(client);
 
+    /* Accept timeout as success if we captured response data (SSE stream) */
+    if ((err == ESP_ERR_HTTP_EAGAIN || err == ESP_ERR_HTTP_CONNECT) &&
+            buf->len > 0) {
+        ESP_LOGD(TAG, "HTTP timeout but captured %u bytes", (unsigned)buf->len);
+        return ESP_OK;
+    }
     if (err != ESP_OK) {
+        ESP_LOGW(TAG, "HTTP perform failed: %s", esp_err_to_name(err));
         return err;
     }
-    if (status != 200) {
+    if (status != 200 && status != 204) {
         ESP_LOGW(TAG, "HTTP status %d", status);
-        return ESP_ERR_HTTP_CONNECT;
+        return ESP_ERR_INVALID_RESPONSE;
     }
     return ESP_OK;
 }
@@ -115,11 +214,15 @@ static esp_err_t cap_mcp_parse_common_input(const char *input_json,
                                             size_t server_url_buf_size,
                                             char *endpoint_buf,
                                             size_t endpoint_buf_size,
+                                            char *auth_token_buf,
+                                            size_t auth_token_buf_size,
+                                            bool *force_initialize,
                                             char *cursor_buf,
                                             size_t cursor_buf_size,
                                             char *tool_name_buf,
                                             size_t tool_name_buf_size,
-                                            cJSON **arguments_out)
+                                            cJSON **arguments_out,
+                                            bool *use_sse_out)
 {
     cJSON *input = cJSON_Parse(input_json);
 
@@ -142,6 +245,21 @@ static esp_err_t cap_mcp_parse_common_input(const char *input_json,
             endpoint = endpoint_item->valuestring;
         }
         strlcpy(endpoint_buf, endpoint, endpoint_buf_size);
+    }
+
+    if (auth_token_buf && auth_token_buf_size > 0) {
+        cJSON *auth_item = cJSON_GetObjectItem(input, "auth_token");
+
+        auth_token_buf[0] = '\0';
+        if (cJSON_IsString(auth_item) && auth_item->valuestring[0]) {
+            strlcpy(auth_token_buf, auth_item->valuestring, auth_token_buf_size);
+        }
+    }
+
+    if (force_initialize) {
+        cJSON *init_item = cJSON_GetObjectItem(input, "initialize");
+
+        *force_initialize = cJSON_IsBool(init_item) && cJSON_IsTrue(init_item);
     }
 
     if (cursor_buf && cursor_buf_size > 0) {
@@ -177,19 +295,46 @@ static esp_err_t cap_mcp_parse_common_input(const char *input_json,
         }
     }
 
+    if (use_sse_out) {
+        cJSON *transport_item = cJSON_GetObjectItem(input, "transport");
+        *use_sse_out = false;
+        if (cJSON_IsString(transport_item) && transport_item->valuestring &&
+                strcmp(transport_item->valuestring, "sse") == 0) {
+            *use_sse_out = true;
+        }
+        /* Also auto-detect: if endpoint starts with /sse */
+        if (!*use_sse_out && endpoint_buf && endpoint_buf_size > 0 &&
+                strncmp(endpoint_buf, "/sse", 4) == 0) {
+            *use_sse_out = true;
+        }
+        if (!*use_sse_out && server_url_buf && strstr(server_url_buf, "/sse")) {
+            *use_sse_out = true;
+        }
+    }
+
     cJSON_Delete(input);
     return ESP_OK;
 }
 
 static esp_err_t cap_mcp_execute_json_rpc(const char *full_url,
                                           cJSON *request,
-                                          cJSON **response_out)
+                                          const char *auth_token,
+                                          const char *session_id,
+                                          cJSON **response_out,
+                                          char *response_session_id,
+                                          size_t response_session_id_size)
 {
     cap_mcp_buf_t response_buf = {0};
     char *body = NULL;
     esp_err_t err;
 
     *response_out = NULL;
+    if (response_session_id && response_session_id_size > 0) {
+        response_session_id[0] = '\0';
+    }
+    
+    ESP_LOGD(TAG, "[RPC] URL=%s Session=%s", full_url, session_id ? session_id : "(none)");
+    
     body = cJSON_PrintUnformatted(request);
     if (!body) {
         return ESP_FAIL;
@@ -203,19 +348,228 @@ static esp_err_t cap_mcp_execute_json_rpc(const char *full_url,
     response_buf.cap = CAP_MCP_RESPONSE_BUF_SIZE;
     response_buf.data[0] = '\0';
 
-    err = cap_mcp_http_post(full_url, body, &response_buf);
+    err = cap_mcp_http_post(full_url, body, auth_token, session_id, &response_buf, response_session_id, response_session_id_size);
     free(body);
     if (err != ESP_OK) {
         free(response_buf.data);
         return err;
     }
 
-    *response_out = cJSON_Parse(response_buf.data);
-    free(response_buf.data);
-    if (!*response_out) {
+    if (response_buf.len == 0) {
+        free(response_buf.data);
+        return ESP_OK;
+    }
+
+    /* Auto-detect: SSE event stream or plain JSON */
+    if (strncmp(response_buf.data, "event:", 6) == 0 ||
+            strncmp(response_buf.data, "data:", 5) == 0) {
+        /* Streamable HTTP: extract JSON from data: line(s) */
+        ESP_LOGI(TAG, "Detected SSE response (%u bytes)", (unsigned)response_buf.len);
+        
+        /* Simple single-pass: find first data: line, extract its JSON */
+        const char *ds = strstr(response_buf.data, "data:");
+        if (ds) {
+            ds += 5;
+            while (*ds == ' ') ds++;
+            /* Find end of this data line */
+            const char *nl = strchr(ds, '\n');
+            size_t json_len = nl ? (size_t)(nl - ds) : strlen(ds);
+            
+            /* Copy to separate buffer for parsing */
+            char *json_buf = malloc(json_len + 1);
+            if (json_buf) {
+                memcpy(json_buf, ds, json_len);
+                json_buf[json_len] = '\0';
+                ESP_LOGD(TAG, "[SSE] JSON (%u bytes)", (unsigned)json_len);
+                *response_out = cJSON_Parse(json_buf);
+                free(json_buf);
+                if (*response_out) {
+                    free(response_buf.data);
+                    return ESP_OK;
+                }
+                ESP_LOGW(TAG, "[SSE] cJSON parse failed on %u bytes", (unsigned)json_len);
+            }
+        }
+        
+        ESP_LOGW(TAG, "SSE parse failed; raw (200): %.*s",
+                 200, response_buf.data);
+        free(response_buf.data);
         return ESP_FAIL;
     }
 
+    /* Plain JSON response */
+    *response_out = cJSON_Parse(response_buf.data);
+    free(response_buf.data);
+    if (!*response_out) {
+        ESP_LOGW(TAG, "JSON parse failed; raw response: %.*s",
+                 (int)(response_buf.len > 256 ? 256 : response_buf.len),
+                 response_buf.data);
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Execute a JSON-RPC call using SSE transport.
+ *
+ * 1. Connects to the SSE endpoint to get the POST URL.
+ * 2. Sends the JSON-RPC request via POST.
+ * 3. Reads the response from the SSE stream.
+ */
+static esp_err_t cap_mcp_execute_json_rpc_sse(const char *server_url,
+                                              const char *sse_endpoint,
+                                              const char *auth_token,
+                                              cJSON *request,
+                                              cJSON **response_out)
+{
+    char *sse_full_url = NULL;
+    char *post_url = NULL;
+    char post_path[192];
+    cap_mcp_sse_ctx_t *sse_ctx = NULL;
+    char *response_buf = NULL;
+    char *body = NULL;
+    size_t server_len;
+    esp_err_t err;
+
+    *response_out = NULL;
+
+    /* Build full SSE URL (heap to save stack) */
+    server_len = strlen(server_url);
+    while (server_len > 0 && server_url[server_len - 1] == '/') server_len--;
+    const char *ep = (sse_endpoint && sse_endpoint[0] == '/') ? sse_endpoint + 1 : sse_endpoint;
+    size_t ep_len = strlen(ep ? ep : "");
+
+    sse_full_url = malloc(server_len + 1 + ep_len + 1);
+    if (!sse_full_url) return ESP_ERR_NO_MEM;
+    memcpy(sse_full_url, server_url, server_len);
+    sse_full_url[server_len] = '/';
+    memcpy(sse_full_url + server_len + 1, ep, ep_len + 1);
+
+    /* Connect SSE and get POST path */
+    err = cap_mcp_sse_connect(sse_full_url, auth_token, &sse_ctx,
+                              post_path, sizeof(post_path));
+    free(sse_full_url);
+    if (err != ESP_OK) return err;
+
+    /* Build full POST URL (heap) */
+    if (post_path[0] == '/') {
+        post_url = malloc(server_len + strlen(post_path) + 1);
+        if (!post_url) { cap_mcp_sse_disconnect(sse_ctx); return ESP_ERR_NO_MEM; }
+        memcpy(post_url, server_url, server_len);
+        strcpy(post_url + server_len, post_path);
+    } else {
+        post_url = malloc(server_len + 1 + strlen(post_path) + 1);
+        if (!post_url) { cap_mcp_sse_disconnect(sse_ctx); return ESP_ERR_NO_MEM; }
+        memcpy(post_url, server_url, server_len);
+        post_url[server_len] = '/';
+        strcpy(post_url + server_len + 1, post_path);
+    }
+
+    body = cJSON_PrintUnformatted(request);
+    if (!body) {
+        free(post_url);
+        cap_mcp_sse_disconnect(sse_ctx);
+        return ESP_FAIL;
+    }
+
+    response_buf = malloc(CAP_MCP_SSE_RESPONSE_SIZE);
+    if (!response_buf) {
+        free(body);
+        free(post_url);
+        cap_mcp_sse_disconnect(sse_ctx);
+        return ESP_ERR_NO_MEM;
+    }
+
+    err = cap_mcp_sse_request(sse_ctx, post_url, auth_token,
+                              body, response_buf, CAP_MCP_SSE_RESPONSE_SIZE);
+    free(body);
+    free(post_url);
+    cap_mcp_sse_disconnect(sse_ctx);
+
+    if (err != ESP_OK) {
+        free(response_buf);
+        return err;
+    }
+
+    if (response_buf[0] == '\0') {
+        free(response_buf);
+        return ESP_OK;
+    }
+
+    *response_out = cJSON_Parse(response_buf);
+    free(response_buf);
+    if (!*response_out) return ESP_FAIL;
+
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_maybe_initialize_session(const char *full_url,
+                                                  const char *auth_token,
+                                                  const char *session_id,
+                                                  bool force_initialize,
+                                                  char *cached_session_id,
+                                                  size_t cached_session_id_size)
+{
+    cJSON *params = NULL;
+    cJSON *request = NULL;
+    cJSON *response = NULL;
+    char response_session_id[128] = {0};
+    esp_err_t err;
+
+    if (!force_initialize && cached_session_id && cached_session_id[0]) {
+        return ESP_OK;
+    }
+
+    params = cJSON_CreateObject();
+    request = cJSON_CreateObject();
+    if (!params || !request) {
+        cJSON_Delete(params);
+        cJSON_Delete(request);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(params, "protocolVersion", "2025-03-26");
+    cJSON *capabilities = cJSON_CreateObject();
+    cJSON *client_info = cJSON_CreateObject();
+    if (!capabilities || !client_info) {
+        cJSON_Delete(params);
+        cJSON_Delete(request);
+        cJSON_Delete(capabilities);
+        cJSON_Delete(client_info);
+        return ESP_ERR_NO_MEM;
+    }
+    cJSON_AddItemToObject(params, "capabilities", capabilities);
+    cJSON_AddStringToObject(client_info, "name", "esp-claw");
+    cJSON_AddStringToObject(client_info, "version", "1.0.0");
+    cJSON_AddItemToObject(params, "clientInfo", client_info);
+
+    cJSON_AddStringToObject(request, "jsonrpc", "2.0");
+    cJSON_AddStringToObject(request, "method", "initialize");
+    cJSON_AddItemToObject(request, "params", params);
+    cJSON_AddNumberToObject(request, "id", CAP_MCP_REQUEST_ID_INIT);
+
+    err = cap_mcp_execute_json_rpc(full_url,
+                                   request,
+                                   auth_token,
+                                   session_id,
+                                   &response,
+                                   response_session_id,
+                                   sizeof(response_session_id));
+    cJSON_Delete(request);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (response_session_id[0] && cached_session_id && cached_session_id_size > 0) {
+        strlcpy(cached_session_id, response_session_id, cached_session_id_size);
+        ESP_LOGI(TAG, "[INIT] Cached Session ID: %s", cached_session_id);
+    } else {
+        ESP_LOGW(TAG, "[INIT] No session ID received (response_session_id[0]=%d, has_cache=%d)",
+                 response_session_id[0], cached_session_id ? 1 : 0);
+    }
+
+    cJSON_Delete(response);
     return ESP_OK;
 }
 
@@ -223,8 +577,11 @@ esp_err_t cap_mcp_list_remote_tools(const char *input_json, cJSON **result_out)
 {
     char server_url_buf[256];
     char endpoint_buf[64];
+    char auth_token_buf[128];
     char cursor_buf[128];
     char full_url[384];
+    bool force_initialize = false;
+    bool use_sse = false;
     cJSON *params = NULL;
     cJSON *request = NULL;
     cJSON *response = NULL;
@@ -246,20 +603,20 @@ esp_err_t cap_mcp_list_remote_tools(const char *input_json, cJSON **result_out)
                                      sizeof(server_url_buf),
                                      endpoint_buf,
                                      sizeof(endpoint_buf),
+                                     auth_token_buf,
+                                     sizeof(auth_token_buf),
+                                     &force_initialize,
                                      cursor_buf,
                                      sizeof(cursor_buf),
                                      NULL,
                                      0,
-                                     NULL);
+                                     NULL,
+                                     &use_sse);
     if (err != ESP_OK) {
         return err;
     }
 
-    cap_mcp_build_full_url(server_url_buf, endpoint_buf, full_url, sizeof(full_url));
-    if (full_url[0] == '\0') {
-        return ESP_ERR_INVALID_ARG;
-    }
-
+    /* Build JSON-RPC request */
     params = cJSON_CreateObject();
     request = cJSON_CreateObject();
     if (!params || !request) {
@@ -276,10 +633,53 @@ esp_err_t cap_mcp_list_remote_tools(const char *input_json, cJSON **result_out)
     cJSON_AddItemToObject(request, "params", params);
     cJSON_AddNumberToObject(request, "id", CAP_MCP_REQUEST_ID_LIST);
 
-    err = cap_mcp_execute_json_rpc(full_url, request, &response);
-    cJSON_Delete(request);
-    if (err != ESP_OK) {
-        return err;
+    if (use_sse) {
+        /* SSE transport path */
+        err = cap_mcp_execute_json_rpc_sse(server_url_buf,
+                                           endpoint_buf,
+                                           auth_token_buf,
+                                           request,
+                                           &response);
+        cJSON_Delete(request);
+        if (err != ESP_OK) {
+            return err;
+        }
+    } else {
+        /* Standard HTTP POST path */
+        cap_mcp_build_full_url(server_url_buf, endpoint_buf, full_url, sizeof(full_url));
+        if (full_url[0] == '\0') {
+            cJSON_Delete(request);
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        if (force_initialize || !s_cached_opts.initialized || strcmp(s_cached_opts.session_id, "") == 0) {
+            err = cap_mcp_maybe_initialize_session(full_url,
+                                                   auth_token_buf,
+                                                   s_cached_opts.session_id[0] ? s_cached_opts.session_id : NULL,
+                                                   force_initialize,
+                                                   s_cached_opts.session_id,
+                                                   sizeof(s_cached_opts.session_id));
+            if (err != ESP_OK) {
+                cJSON_Delete(request);
+                return err;
+            }
+            s_cached_opts.initialized = true;
+            strlcpy(s_cached_opts.auth_token, auth_token_buf, sizeof(s_cached_opts.auth_token));
+            ESP_LOGI(TAG, "[LIST] After init: cached session=%s", s_cached_opts.session_id);
+        }
+
+        ESP_LOGD(TAG, "[LIST] Using session_id: %s", s_cached_opts.session_id);
+        err = cap_mcp_execute_json_rpc(full_url,
+                                       request,
+                                       auth_token_buf,
+                                       s_cached_opts.session_id,
+                                       &response,
+                                       NULL,
+                                       0);
+        cJSON_Delete(request);
+        if (err != ESP_OK) {
+            return err;
+        }
     }
 
     root = cJSON_CreateObject();
@@ -340,8 +740,11 @@ esp_err_t cap_mcp_call_remote_tool(const char *input_json, cJSON **result_out)
 {
     char server_url_buf[256];
     char endpoint_buf[64];
+    char auth_token_buf[128];
     char tool_name_buf[128];
     char full_url[384];
+    bool force_initialize = false;
+    bool use_sse = false;
     cJSON *arguments = NULL;
     cJSON *params = NULL;
     cJSON *request = NULL;
@@ -361,22 +764,21 @@ esp_err_t cap_mcp_call_remote_tool(const char *input_json, cJSON **result_out)
                                      sizeof(server_url_buf),
                                      endpoint_buf,
                                      sizeof(endpoint_buf),
+                                     auth_token_buf,
+                                     sizeof(auth_token_buf),
+                                     &force_initialize,
                                      NULL,
                                      0,
                                      tool_name_buf,
                                      sizeof(tool_name_buf),
-                                     &arguments);
+                                     &arguments,
+                                     &use_sse);
     if (err != ESP_OK) {
         cJSON_Delete(arguments);
         return err;
     }
 
-    cap_mcp_build_full_url(server_url_buf, endpoint_buf, full_url, sizeof(full_url));
-    if (full_url[0] == '\0') {
-        cJSON_Delete(arguments);
-        return ESP_ERR_INVALID_ARG;
-    }
-
+    /* Build JSON-RPC request */
     params = cJSON_CreateObject();
     request = cJSON_CreateObject();
     if (!params || !request) {
@@ -393,10 +795,51 @@ esp_err_t cap_mcp_call_remote_tool(const char *input_json, cJSON **result_out)
     cJSON_AddItemToObject(request, "params", params);
     cJSON_AddNumberToObject(request, "id", CAP_MCP_REQUEST_ID_CALL);
 
-    err = cap_mcp_execute_json_rpc(full_url, request, &response);
-    cJSON_Delete(request);
-    if (err != ESP_OK) {
-        return err;
+    if (use_sse) {
+        /* SSE transport path */
+        err = cap_mcp_execute_json_rpc_sse(server_url_buf,
+                                           endpoint_buf,
+                                           auth_token_buf,
+                                           request,
+                                           &response);
+        cJSON_Delete(request);
+        if (err != ESP_OK) {
+            return err;
+        }
+    } else {
+        /* Standard HTTP POST path */
+        cap_mcp_build_full_url(server_url_buf, endpoint_buf, full_url, sizeof(full_url));
+        if (full_url[0] == '\0') {
+            cJSON_Delete(request);
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        if (force_initialize || !s_cached_opts.initialized || strcmp(s_cached_opts.session_id, "") == 0) {
+            err = cap_mcp_maybe_initialize_session(full_url,
+                                                   auth_token_buf,
+                                                   s_cached_opts.session_id[0] ? s_cached_opts.session_id : NULL,
+                                                   force_initialize,
+                                                   s_cached_opts.session_id,
+                                                   sizeof(s_cached_opts.session_id));
+            if (err != ESP_OK) {
+                cJSON_Delete(request);
+                return err;
+            }
+            s_cached_opts.initialized = true;
+            strlcpy(s_cached_opts.auth_token, auth_token_buf, sizeof(s_cached_opts.auth_token));
+        }
+
+        err = cap_mcp_execute_json_rpc(full_url,
+                                       request,
+                                       auth_token_buf,
+                                       s_cached_opts.session_id,
+                                       &response,
+                                       NULL,
+                                       0);
+        cJSON_Delete(request);
+        if (err != ESP_OK) {
+            return err;
+        }
     }
 
     root = cJSON_CreateObject();

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_internal.h
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_internal.h
@@ -8,7 +8,7 @@
 #include "cJSON.h"
 #include "esp_err.h"
 
-#define CAP_MCP_DEFAULT_ENDPOINT      "mcp_server"
+#define CAP_MCP_DEFAULT_ENDPOINT      "mcp"
 #define CAP_MCP_MDNS_SERVICE_TYPE     "_mcp"
 #define CAP_MCP_MDNS_SERVICE_PROTO    "_tcp"
 #define CAP_MCP_DISCOVER_TIMEOUT_MS   3000

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_sse.c
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_sse.c
@@ -1,0 +1,266 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * MCP Streamable-HTTP / SSE transport client.
+ * Uses esp_http_client_perform() with event handler to capture the
+ * SSE response stream that the server sends as the HTTP response body.
+ */
+#include "cap_mcp_client_sse.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "esp_crt_bundle.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+
+static const char *TAG = "mcp_client_sse";
+
+#define SSE_BUF_SIZE           8192
+#define SSE_GET_TIMEOUT_MS     5000   /* SSE GET must complete quickly */
+#define SSE_POST_TIMEOUT_MS    5000   /* SSE POST must complete quickly */
+
+/* ─── Event-handler based capture ──────────────────────────────────── */
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+} sse_cap_t;
+
+static esp_err_t sse_cap_handler(esp_http_client_event_t *event)
+{
+    sse_cap_t *c = (sse_cap_t *)event->user_data;
+    if (!c || event->event_id != HTTP_EVENT_ON_DATA || !c->buf) return ESP_OK;
+
+    /* Grow buffer if needed */
+    if (c->len + event->data_len + 1 > c->cap) {
+        size_t need = c->len + event->data_len + 1;
+        size_t nc = (c->cap < need) ? need : c->cap * 2;
+        char *nb = realloc(c->buf, nc);
+        if (!nb) return ESP_ERR_NO_MEM;
+        c->buf = nb;
+        c->cap = nc;
+    }
+    memcpy(c->buf + c->len, event->data, event->data_len);
+    c->len += event->data_len;
+    c->buf[c->len] = '\0';
+    return ESP_OK;
+}
+
+/* ─── SSE line parser ──────────────────────────────────────────────── */
+
+/** Return length of next line (without \r\n), advance *cursor past \n. */
+static int sse_next_line(const char **cursor)
+{
+    const char *s = *cursor;
+    if (!s || !*s) return -1;
+    const char *nl = strchr(s, '\n');
+    int len;
+    if (nl) {
+        len = (int)(nl - s);
+        if (len > 0 && nl[-1] == '\r') len--;
+        *cursor = nl + 1;
+    } else {
+        len = (int)strlen(s);
+        *cursor = s + len;
+    }
+    return len;
+}
+
+/**
+ * @brief Extract the data payload of the first SSE event matching @p event_name.
+ */
+static esp_err_t sse_find_event(const char *body, size_t body_len,
+                                const char *event_name,
+                                char *data_out, size_t data_size)
+{
+    const char *cur = body;
+    char ev[64] = "";
+    char dt[SSE_BUF_SIZE] = "";
+    bool in = false;
+
+    data_out[0] = '\0';
+
+    while (cur < body + body_len) {
+        const char *line_start = cur;
+        int len = sse_next_line(&cur);
+        if (len < 0) break;
+
+        if (len == 0) {
+            if (in && strcmp(ev, event_name) == 0) {
+                strlcpy(data_out, dt, data_size);
+                return ESP_OK;
+            }
+            ev[0] = '\0'; dt[0] = '\0'; in = false;
+            continue;
+        }
+        in = true;
+        if (len > 6 && strncmp(line_start, "event:", 6) == 0) {
+            const char *v = line_start + 6;
+            while (*v == ' ' || *v == '\t') v++;
+            strlcpy(ev, v, sizeof(ev));
+        } else if (len > 5 && strncmp(line_start, "data:", 5) == 0) {
+            const char *v = line_start + 5;
+            while (*v == ' ' || *v == '\t') v++;
+            if (dt[0]) strlcat(dt, "\n", sizeof(dt));
+            strlcat(dt, v, sizeof(dt));
+        }
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+/* ─── Public API ───────────────────────────────────────────────────── */
+
+esp_err_t cap_mcp_sse_connect(const char *sse_url,
+                              const char *auth_token,
+                              cap_mcp_sse_ctx_t **ctx_out,
+                              char *post_url_out,
+                              size_t post_url_size)
+{
+    (void)ctx_out;
+    if (!sse_url || !post_url_out || post_url_size == 0)
+        return ESP_ERR_INVALID_ARG;
+    post_url_out[0] = '\0';
+
+    sse_cap_t c = { .buf = calloc(1, 2048), .len = 0, .cap = 2048 };
+    if (!c.buf) return ESP_ERR_NO_MEM;
+
+    esp_http_client_config_t cfg = {
+        .url = sse_url,
+        .method = HTTP_METHOD_GET,
+        .event_handler = sse_cap_handler,
+        .user_data = &c,
+        .timeout_ms = SSE_GET_TIMEOUT_MS,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+    esp_http_client_handle_t cl = esp_http_client_init(&cfg);
+    if (!cl) { free(c.buf); return ESP_ERR_NO_MEM; }
+
+    esp_http_client_set_header(cl, "Accept", "text/event-stream");
+    if (auth_token && auth_token[0]) {
+        char bh[160];
+        snprintf(bh, sizeof(bh), "Bearer %s", auth_token);
+        esp_http_client_set_header(cl, "Authorization", bh);
+    }
+
+    esp_err_t err = esp_http_client_perform(cl);
+    int st = esp_http_client_get_status_code(cl);
+    esp_http_client_cleanup(cl);
+
+    /* Accept timeout as success if we captured SSE data */
+    if (err == ESP_ERR_HTTP_EAGAIN && c.len > 0) {
+        ESP_LOGI(TAG, "SSE GET timeout but captured %u bytes", (unsigned)c.len);
+        err = ESP_OK;
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "SSE GET err=%s len=%u", esp_err_to_name(err), (unsigned)c.len);
+        free(c.buf); return err;
+    }
+    if (st != 200 && st != 0) {  /* st=0 when timeout */
+        ESP_LOGW(TAG, "SSE GET HTTP %d", st);
+        free(c.buf); return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    ESP_LOGI(TAG, "SSE GET ok, body=%u bytes", (unsigned)c.len);
+
+    /* Extract endpoint event */
+    err = sse_find_event(c.buf, c.len, "endpoint", post_url_out, post_url_size);
+    if (err != ESP_OK) {
+        const char *ds = strstr(c.buf, "data:");
+        if (ds) {
+            ds += 5; while (*ds == ' ') ds++;
+            const char *nl = strchr(ds, '\n');
+            size_t cp = nl ? (size_t)(nl - ds) : strlen(ds);
+            if (cp >= post_url_size) cp = post_url_size - 1;
+            memcpy(post_url_out, ds, cp);
+            post_url_out[cp] = '\0';
+            err = ESP_OK;
+        }
+    }
+
+    if (post_url_out[0])
+        ESP_LOGI(TAG, "SSE endpoint: %s", post_url_out);
+    else
+        ESP_LOGW(TAG, "SSE body: %.*s", (int)(c.len > 200 ? 200 : c.len), c.buf);
+
+    free(c.buf);
+    return (post_url_out[0] ? ESP_OK : ESP_ERR_NOT_FOUND);
+}
+
+esp_err_t cap_mcp_sse_request(cap_mcp_sse_ctx_t *ctx,
+                              const char *post_url,
+                              const char *auth_token,
+                              const char *json_rpc_body,
+                              char *response,
+                              size_t response_size)
+{
+    (void)ctx;
+    if (!post_url || !json_rpc_body || !response || response_size == 0)
+        return ESP_ERR_INVALID_ARG;
+    response[0] = '\0';
+
+    sse_cap_t c = { .buf = calloc(1, 2048), .len = 0, .cap = 2048 };
+    if (!c.buf) return ESP_ERR_NO_MEM;
+
+    esp_http_client_config_t cfg = {
+        .url = post_url,
+        .method = HTTP_METHOD_POST,
+        .event_handler = sse_cap_handler,
+        .user_data = &c,
+        .timeout_ms = SSE_POST_TIMEOUT_MS,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+    esp_http_client_handle_t cl = esp_http_client_init(&cfg);
+    if (!cl) { free(c.buf); return ESP_ERR_NO_MEM; }
+
+    esp_http_client_set_header(cl, "Content-Type", "application/json");
+    esp_http_client_set_header(cl, "Accept", "application/json, text/event-stream");
+    if (auth_token && auth_token[0]) {
+        char bh[160];
+        snprintf(bh, sizeof(bh), "Bearer %s", auth_token);
+        esp_http_client_set_header(cl, "Authorization", bh);
+    }
+    esp_http_client_set_post_field(cl, json_rpc_body, (int)strlen(json_rpc_body));
+
+    esp_err_t err = esp_http_client_perform(cl);
+    int st = esp_http_client_get_status_code(cl);
+    esp_http_client_cleanup(cl);
+
+    /* Accept timeout as success if we captured SSE data */
+    if (err == ESP_ERR_HTTP_EAGAIN && c.len > 0) {
+        ESP_LOGD(TAG, "SSE POST timeout but captured %u bytes", (unsigned)c.len);
+        err = ESP_OK;
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "SSE POST err=%s len=%u", esp_err_to_name(err), (unsigned)c.len);
+        free(c.buf); return err;
+    }
+    if (st != 200 && st != 0) {
+        ESP_LOGW(TAG, "SSE POST HTTP %d", st);
+        free(c.buf); return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    /* Extract "message" event (JSON-RPC response) */
+    err = sse_find_event(c.buf, c.len, "message", response, response_size);
+    if (err != ESP_OK) {
+        if (c.len > 0 && c.buf[0] == '{') {
+            strlcpy(response, c.buf, response_size);
+            err = ESP_OK;
+        } else {
+            ESP_LOGW(TAG, "SSE body: %.*s",
+                     (int)(c.len > 256 ? 256 : c.len), c.buf);
+        }
+    }
+
+    free(c.buf);
+    return err;
+}
+
+void cap_mcp_sse_disconnect(cap_mcp_sse_ctx_t *ctx)
+{
+    free(ctx);
+}

--- a/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_sse.h
+++ b/components/claw_capabilities/cap_mcp_client/src/cap_mcp_client_sse.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief SSE transport context (opaque)
+ */
+typedef struct cap_mcp_sse_ctx cap_mcp_sse_ctx_t;
+
+/**
+ * @brief Connect to an MCP SSE endpoint and extract the message POST URL.
+ *
+ * Performs HTTP GET to the SSE endpoint, reads the "endpoint" event,
+ * and returns the session-specific POST URL for JSON-RPC messages.
+ *
+ * @param[in]  sse_url        Full SSE endpoint URL (e.g. http://host:3000/sse/device-id)
+ * @param[in]  auth_token     Optional Bearer token (NULL if not needed)
+ * @param[out] ctx_out        SSE context for subsequent requests
+ * @param[out] post_url_out   Buffer to receive the POST URL from endpoint event
+ * @param[in]  post_url_size  Size of post_url_out buffer
+ * @return ESP_OK on success
+ */
+esp_err_t cap_mcp_sse_connect(const char *sse_url,
+                              const char *auth_token,
+                              cap_mcp_sse_ctx_t **ctx_out,
+                              char *post_url_out,
+                              size_t post_url_size);
+
+/**
+ * @brief Send a JSON-RPC request and wait for the response via SSE.
+ *
+ * POSTs the JSON-RPC body to the message endpoint, then reads the
+ * SSE stream until a "message" event is received.
+ *
+ * @param[in]  ctx            SSE context from cap_mcp_sse_connect()
+ * @param[in]  post_url       POST URL (from endpoint event)
+ * @param[in]  auth_token     Optional Bearer token
+ * @param[in]  json_rpc_body  JSON-RPC request body
+ * @param[out] response       Buffer for JSON-RPC response
+ * @param[in]  response_size  Size of response buffer
+ * @return ESP_OK on success
+ */
+esp_err_t cap_mcp_sse_request(cap_mcp_sse_ctx_t *ctx,
+                              const char *post_url,
+                              const char *auth_token,
+                              const char *json_rpc_body,
+                              char *response,
+                              size_t response_size);
+
+/**
+ * @brief Disconnect SSE and free resources.
+ *
+ * @param[in] ctx  SSE context to clean up
+ */
+void cap_mcp_sse_disconnect(cap_mcp_sse_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/claw_capabilities/cap_mcp_client/src/cmd_cap_mcp_client.c
+++ b/components/claw_capabilities/cap_mcp_client/src/cmd_cap_mcp_client.c
@@ -22,6 +22,9 @@ static struct {
     struct arg_str *cursor;
     struct arg_str *tool_name;
     struct arg_str *arguments_json;
+    struct arg_str *auth_token;
+    struct arg_lit *initialize;
+    struct arg_str *transport;
     struct arg_int *timeout_ms;
     struct arg_lit *include_self;
     struct arg_end *end;
@@ -107,6 +110,15 @@ static int mcp_client_func(int argc, char **argv)
         if (mcp_client_args.endpoint->count) {
             cJSON_AddStringToObject(root, "endpoint", mcp_client_args.endpoint->sval[0]);
         }
+        if (mcp_client_args.auth_token->count) {
+            cJSON_AddStringToObject(root, "auth_token", mcp_client_args.auth_token->sval[0]);
+        }
+        if (mcp_client_args.transport->count) {
+            cJSON_AddStringToObject(root, "transport", mcp_client_args.transport->sval[0]);
+        }
+        if (mcp_client_args.initialize->count) {
+            cJSON_AddBoolToObject(root, "initialize", true);
+        }
 
         if (mcp_client_args.list_tools->count) {
             cap_name = "mcp_list_tools";
@@ -150,9 +162,12 @@ void register_cap_mcp_client(void)
     mcp_client_args.cursor = arg_str0(NULL, "cursor", "<cursor>", "Pagination cursor for list-tools");
     mcp_client_args.tool_name = arg_str0(NULL, "tool-name", "<name>", "Remote MCP tool name");
     mcp_client_args.arguments_json = arg_str0(NULL, "arguments-json", "<json>", "Remote MCP tool arguments JSON object");
+    mcp_client_args.auth_token = arg_str0(NULL, "auth-token", "<token>", "Bearer token for MCP server auth");
+    mcp_client_args.initialize = arg_lit0(NULL, "initialize", "Force MCP initialize handshake before request");
+    mcp_client_args.transport = arg_str0(NULL, "transport", "<http|sse>", "Transport mode: http (default) or sse");
     mcp_client_args.timeout_ms = arg_int0(NULL, "timeout-ms", "<ms>", "Discovery timeout in milliseconds");
     mcp_client_args.include_self = arg_lit0(NULL, "include-self", "Include the local device in discovery");
-    mcp_client_args.end = arg_end(10);
+    mcp_client_args.end = arg_end(12);
 
     const esp_console_cmd_t mcp_client_cmd = {
         .command = "mcp_client",
@@ -160,7 +175,9 @@ void register_cap_mcp_client(void)
         "Examples:\n"
         " mcp_client --discover --timeout-ms 3000\n"
         " mcp_client --list-tools --server-url http://host.local:18791 --endpoint mcp_server\n"
-        " mcp_client --call-tool --server-url http://host.local:18791 --tool-name device.describe\n",
+        " mcp_client --call-tool --server-url http://host.local:18791 --tool-name device.describe\n"
+        " mcp_client --list-tools --server-url http://host.local:18791 --auth-token secret-token --initialize\n"
+        " mcp_client --list-tools --server-url http://cloud.example.com:3000 --endpoint /sse/device-id --transport sse --auth-token secret-token\n",
         .func = mcp_client_func,
         .argtable = &mcp_client_args,
     };

--- a/components/claw_capabilities/cap_mcp_server/CHANGELOG.md
+++ b/components/claw_capabilities/cap_mcp_server/CHANGELOG.md
@@ -1,0 +1,13 @@
+# MCP Server 改动记录
+
+## 2026-05-05 — 本轮无修改
+
+`cap_mcp_server` 在本轮调试中未做任何代码修改。
+
+### 相关上下文
+
+MCP Server（`http://esp-claw.local:18791/mcp_server`）工作正常，服务端能力未受影响。
+
+MCP Client 的调试和修复主要涉及：
+- `cap_mcp_client` 组件（Session 提取、SSE 解析、缓冲区）
+- `app_capabilities.c`（LLM 可见性配置）

--- a/components/claw_capabilities/cap_mcp_server/CMakeLists.txt
+++ b/components/claw_capabilities/cap_mcp_server/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(
     SRCS
+        "src/cap_mcp_transport_http_auth.c"
         "src/cap_mcp_server.c"
         "src/cmd_cap_mcp_server.c"
     INCLUDE_DIRS

--- a/components/claw_capabilities/cap_mcp_server/include/cap_mcp_server.h
+++ b/components/claw_capabilities/cap_mcp_server/include/cap_mcp_server.h
@@ -23,6 +23,7 @@ typedef struct {
     const char *endpoint;
     uint16_t server_port;
     uint16_t ctrl_port;
+    const char *auth_token;
 } cap_mcp_server_config_t;
 
 esp_err_t cap_mcp_server_register_group(void);

--- a/components/claw_capabilities/cap_mcp_server/include/cap_mcp_transport_http_auth.h
+++ b/components/claw_capabilities/cap_mcp_server/include/cap_mcp_transport_http_auth.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_http_server.h"
+#include "esp_mcp_mgr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    httpd_config_t http_config;
+    const char *auth_token;
+} cap_mcp_http_auth_config_t;
+
+extern const esp_mcp_transport_t cap_mcp_transport_http_server_auth;
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/claw_capabilities/cap_mcp_server/src/cap_mcp_server.c
+++ b/components/claw_capabilities/cap_mcp_server/src/cap_mcp_server.c
@@ -5,6 +5,8 @@
  */
 #include "cap_mcp_server.h"
 
+#include "cap_mcp_transport_http_auth.h"
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,7 +37,7 @@ typedef struct {
     const char *name;
     const char *description;
     esp_mcp_value_t (*callback)(const esp_mcp_property_list_t *properties);
-    const char *property_names[6];
+    const char *property_names[7];
     size_t property_count;
 } cap_mcp_server_tool_def_t;
 
@@ -45,6 +47,7 @@ typedef struct {
     char endpoint[64];
     uint16_t server_port;
     uint16_t ctrl_port;
+    char auth_token[128];
 } cap_mcp_server_runtime_config_t;
 
 static cap_mcp_server_runtime_config_t s_config = {
@@ -53,6 +56,7 @@ static cap_mcp_server_runtime_config_t s_config = {
     .endpoint = CAP_MCP_SERVER_DEFAULT_ENDPOINT,
     .server_port = CAP_MCP_SERVER_DEFAULT_PORT,
     .ctrl_port = CAP_MCP_SERVER_DEFAULT_CTRL_PORT,
+    .auth_token = "",
 };
 static esp_mcp_t *s_mcp;
 static esp_mcp_mgr_handle_t s_mgr;
@@ -183,6 +187,8 @@ static esp_mcp_value_t cap_mcp_server_emit_event_callback(
     const char *text = esp_mcp_property_list_get_property_string(properties, "text");
     const char *target_channel = esp_mcp_property_list_get_property_string(properties, "target_channel");
     const char *target_endpoint = esp_mcp_property_list_get_property_string(properties, "target_endpoint");
+    const char *source_channel = esp_mcp_property_list_get_property_string(properties, "source_channel");
+    const char *content_type = esp_mcp_property_list_get_property_string(properties, "content_type");
     const char *payload_json = esp_mcp_property_list_get_property_string(properties, "payload_json");
     claw_event_t event = {0};
     cJSON *resp = NULL;
@@ -194,8 +200,11 @@ static esp_mcp_value_t cap_mcp_server_emit_event_callback(
     strlcpy(event.event_id, "mcp-emit", sizeof(event.event_id));
     strlcpy(event.source_cap, "mcp_server", sizeof(event.source_cap));
     strlcpy(event.event_type, event_type, sizeof(event.event_type));
-    strlcpy(event.source_channel, "mcp", sizeof(event.source_channel));
-    strlcpy(event.content_type, (payload_json && payload_json[0]) ? "json" : "text",
+        strlcpy(event.source_channel,
+            (source_channel && source_channel[0]) ? source_channel : "mcp",
+            sizeof(event.source_channel));
+        strlcpy(event.content_type,
+            (content_type && content_type[0]) ? content_type : ((payload_json && payload_json[0]) ? "json" : "text"),
             sizeof(event.content_type));
     strlcpy(event.target_channel, target_channel ? target_channel : "", sizeof(event.target_channel));
     strlcpy(event.target_endpoint, target_endpoint ? target_endpoint : "", sizeof(event.target_endpoint));
@@ -264,10 +273,10 @@ static esp_err_t cap_mcp_server_register_tools(void)
         },
         {
             .name = "router.emit_event",
-            .description = "Emit a standard router event into esp-claw. Provide event_type and optional text, target_channel, target_endpoint, payload_json.",
+            .description = "Emit a standard router event into esp-claw. Provide event_type and optional text, source_channel, content_type, target_channel, target_endpoint, payload_json.",
             .callback = cap_mcp_server_emit_event_callback,
-            .property_names = {"event_type", "text", "target_channel", "target_endpoint", "payload_json"},
-            .property_count = 5,
+            .property_names = {"event_type", "text", "source_channel", "content_type", "target_channel", "target_endpoint", "payload_json"},
+            .property_count = 7,
         },
     };
     size_t i = 0;
@@ -337,6 +346,7 @@ static esp_err_t cap_mcp_server_descriptor_init(void)
 static esp_err_t cap_mcp_server_descriptor_start(void)
 {
     httpd_config_t http_config = HTTPD_DEFAULT_CONFIG();
+    cap_mcp_http_auth_config_t transport_config = {0};
     esp_mcp_mgr_config_t config;
     esp_err_t err;
 
@@ -362,8 +372,11 @@ static esp_err_t cap_mcp_server_descriptor_start(void)
     http_config.max_uri_handlers = 4;
     http_config.stack_size = 8192;
 
-    config.transport = esp_mcp_transport_http_server;
-    config.config = &http_config;
+    transport_config.http_config = http_config;
+    transport_config.auth_token = s_config.auth_token[0] ? s_config.auth_token : NULL;
+
+    config.transport = cap_mcp_transport_http_server_auth;
+    config.config = &transport_config;
     config.instance = s_mcp;
 
     err = esp_mcp_mgr_init(config, &s_mgr);
@@ -487,6 +500,9 @@ esp_err_t cap_mcp_server_set_config(const cap_mcp_server_config_t *config)
     if (config->ctrl_port != 0) {
         s_config.ctrl_port = config->ctrl_port;
     }
+    if (config->auth_token) {
+        strlcpy(s_config.auth_token, config->auth_token, sizeof(s_config.auth_token));
+    }
 
     return ESP_OK;
 }
@@ -502,6 +518,7 @@ esp_err_t cap_mcp_server_get_config(cap_mcp_server_config_t *config, bool *start
     config->endpoint = s_config.endpoint;
     config->server_port = s_config.server_port;
     config->ctrl_port = s_config.ctrl_port;
+    config->auth_token = s_config.auth_token;
     if (started) {
         *started = s_started;
     }

--- a/components/claw_capabilities/cap_mcp_server/src/cap_mcp_server.c
+++ b/components/claw_capabilities/cap_mcp_server/src/cap_mcp_server.c
@@ -23,9 +23,23 @@
 #include "esp_mcp_mgr.h"
 #include "esp_mcp_property.h"
 #include "esp_mcp_tool.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "mdns.h"
 
 static const char *TAG = "cap_mcp_srv";
+
+#define CAP_MCP_REPLY_BUF_SIZE   5
+#define CAP_MCP_REPLY_TEXT_MAX   4096
+
+typedef struct {
+    char replies[CAP_MCP_REPLY_BUF_SIZE][CAP_MCP_REPLY_TEXT_MAX];
+    int head;
+    int count;
+    SemaphoreHandle_t lock;
+} cap_mcp_reply_buf_t;
+
+static cap_mcp_reply_buf_t s_reply_buf;
 
 #define CAP_MCP_SERVER_DEFAULT_ENDPOINT      "mcp_server"
 #define CAP_MCP_SERVER_DEFAULT_SERVICE_TYPE  "_mcp"
@@ -37,7 +51,7 @@ typedef struct {
     const char *name;
     const char *description;
     esp_mcp_value_t (*callback)(const esp_mcp_property_list_t *properties);
-    const char *property_names[7];
+    const char *property_names[9];
     size_t property_count;
 } cap_mcp_server_tool_def_t;
 
@@ -62,6 +76,53 @@ static esp_mcp_t *s_mcp;
 static esp_mcp_mgr_handle_t s_mgr;
 static bool s_tools_registered;
 static bool s_started;
+
+static void cap_mcp_reply_buf_init(void)
+{
+    s_reply_buf.head = 0;
+    s_reply_buf.count = 0;
+    s_reply_buf.lock = xSemaphoreCreateMutex();
+}
+
+static void cap_mcp_reply_buf_push(const char *text)
+{
+    if (!s_reply_buf.lock) return;
+    if (!text || !text[0]) return;
+
+    if (xSemaphoreTake(s_reply_buf.lock, portMAX_DELAY) == pdTRUE) {
+        strlcpy(s_reply_buf.replies[s_reply_buf.head], text, CAP_MCP_REPLY_TEXT_MAX);
+        s_reply_buf.head = (s_reply_buf.head + 1) % CAP_MCP_REPLY_BUF_SIZE;
+        if (s_reply_buf.count < CAP_MCP_REPLY_BUF_SIZE) {
+            s_reply_buf.count++;
+        }
+        xSemaphoreGive(s_reply_buf.lock);
+    }
+}
+
+static esp_err_t cap_mcp_reply_buf_read_all(char *output, size_t output_size)
+{
+    if (!s_reply_buf.lock) return ESP_ERR_INVALID_STATE;
+
+    output[0] = '\0';
+    if (xSemaphoreTake(s_reply_buf.lock, portMAX_DELAY) == pdTRUE) {
+        cJSON *arr = cJSON_CreateArray();
+        if (arr) {
+            int idx = (s_reply_buf.head - s_reply_buf.count + CAP_MCP_REPLY_BUF_SIZE) % CAP_MCP_REPLY_BUF_SIZE;
+            for (int i = 0; i < s_reply_buf.count; i++) {
+                cJSON_AddItemToArray(arr, cJSON_CreateString(s_reply_buf.replies[idx]));
+                idx = (idx + 1) % CAP_MCP_REPLY_BUF_SIZE;
+            }
+            char *json = cJSON_PrintUnformatted(arr);
+            cJSON_Delete(arr);
+            if (json) {
+                strlcpy(output, json, output_size);
+                free(json);
+            }
+        }
+        xSemaphoreGive(s_reply_buf.lock);
+    }
+    return output[0] ? ESP_OK : ESP_ERR_NOT_FOUND;
+}
 
 static int cap_mcp_server_current_time_ms(void)
 {
@@ -189,6 +250,8 @@ static esp_mcp_value_t cap_mcp_server_emit_event_callback(
     const char *target_endpoint = esp_mcp_property_list_get_property_string(properties, "target_endpoint");
     const char *source_channel = esp_mcp_property_list_get_property_string(properties, "source_channel");
     const char *content_type = esp_mcp_property_list_get_property_string(properties, "content_type");
+    const char *chat_id = esp_mcp_property_list_get_property_string(properties, "chat_id");
+    const char *sender_id = esp_mcp_property_list_get_property_string(properties, "sender_id");
     const char *payload_json = esp_mcp_property_list_get_property_string(properties, "payload_json");
     claw_event_t event = {0};
     cJSON *resp = NULL;
@@ -208,6 +271,8 @@ static esp_mcp_value_t cap_mcp_server_emit_event_callback(
             sizeof(event.content_type));
     strlcpy(event.target_channel, target_channel ? target_channel : "", sizeof(event.target_channel));
     strlcpy(event.target_endpoint, target_endpoint ? target_endpoint : "", sizeof(event.target_endpoint));
+    strlcpy(event.chat_id, chat_id ? chat_id : "", sizeof(event.chat_id));
+    strlcpy(event.sender_id, sender_id ? sender_id : "", sizeof(event.sender_id));
     strlcpy(event.message_id, event_type, sizeof(event.message_id));
     strlcpy(event.correlation_id, event_type, sizeof(event.correlation_id));
     event.timestamp_ms = cap_mcp_server_current_time_ms();
@@ -228,6 +293,54 @@ static esp_mcp_value_t cap_mcp_server_emit_event_callback(
     cJSON_AddStringToObject(resp, "target_channel", target_channel ? target_channel : "");
     cJSON_AddStringToObject(resp, "target_endpoint", target_endpoint ? target_endpoint : "");
     return cap_mcp_server_result_json(resp);
+}
+
+static esp_mcp_value_t cap_mcp_server_agent_chat_callback(
+    const esp_mcp_property_list_t *properties)
+{
+    const char *text = esp_mcp_property_list_get_property_string(properties, "text");
+    const char *chat_id = esp_mcp_property_list_get_property_string(properties, "chat_id");
+    claw_event_t event = {0};
+
+    if (!text || !text[0]) {
+        return esp_mcp_value_create_bool(false);
+    }
+
+    strlcpy(event.event_id, "mcp-chat", sizeof(event.event_id));
+    strlcpy(event.source_cap, "mcp_server", sizeof(event.source_cap));
+    strlcpy(event.event_type, "message", sizeof(event.event_type));
+    strlcpy(event.source_channel, "mcp_reply", sizeof(event.source_channel));
+    strlcpy(event.content_type, "text", sizeof(event.content_type));
+    strlcpy(event.chat_id, chat_id && chat_id[0] ? chat_id : "mcp_chat", sizeof(event.chat_id));
+    strlcpy(event.message_id, "text", sizeof(event.message_id));
+    strlcpy(event.correlation_id, "mcp-chat", sizeof(event.correlation_id));
+    event.timestamp_ms = cap_mcp_server_current_time_ms();
+    event.session_policy = CLAW_EVENT_SESSION_POLICY_CHAT;
+    event.text = (char *)text;
+
+    if (claw_event_router_publish(&event) != ESP_OK) {
+        return esp_mcp_value_create_bool(false);
+    }
+
+    cJSON *resp = cJSON_CreateObject();
+    if (!resp) {
+        return esp_mcp_value_create_bool(false);
+    }
+    cJSON_AddBoolToObject(resp, "accepted", true);
+    return cap_mcp_server_result_json(resp);
+}
+
+static esp_mcp_value_t cap_mcp_server_agent_get_replies_callback(
+    const esp_mcp_property_list_t *properties)
+{
+    char buf[4096] = {0};
+    (void)properties;
+
+    cap_mcp_reply_buf_read_all(buf, sizeof(buf));
+    if (!buf[0]) {
+        return esp_mcp_value_create_string("[]");
+    }
+    return esp_mcp_value_create_string(buf);
 }
 
 static esp_err_t cap_mcp_server_register_tool(
@@ -273,10 +386,23 @@ static esp_err_t cap_mcp_server_register_tools(void)
         },
         {
             .name = "router.emit_event",
-            .description = "Emit a standard router event into esp-claw. Provide event_type and optional text, source_channel, content_type, target_channel, target_endpoint, payload_json.",
+            .description = "Emit a standard router event into esp-claw. Provide event_type and optional text, source_channel, content_type, chat_id, sender_id, target_channel, target_endpoint, payload_json.",
             .callback = cap_mcp_server_emit_event_callback,
-            .property_names = {"event_type", "text", "source_channel", "content_type", "target_channel", "target_endpoint", "payload_json"},
-            .property_count = 7,
+            .property_names = {"event_type", "text", "source_channel", "content_type", "chat_id", "sender_id", "target_channel", "target_endpoint", "payload_json"},
+            .property_count = 9,
+        },
+        {
+            .name = "agent.chat",
+            .description = "Send a text message to the AI agent. The agent will process it and the reply can be retrieved with agent.get_replies. Provide text and optional chat_id.",
+            .callback = cap_mcp_server_agent_chat_callback,
+            .property_names = {"text", "chat_id"},
+            .property_count = 2,
+        },
+        {
+            .name = "agent.get_replies",
+            .description = "Retrieve recent AI agent replies. Returns a JSON array of reply texts, newest last.",
+            .callback = cap_mcp_server_agent_get_replies_callback,
+            .property_count = 0,
         },
     };
     size_t i = 0;
@@ -338,6 +464,7 @@ static esp_err_t cap_mcp_server_descriptor_init(void)
         return ESP_OK;
     }
 
+    cap_mcp_reply_buf_init();
     ESP_RETURN_ON_ERROR(esp_mcp_create(&s_mcp), TAG, "Failed to create MCP engine");
     ESP_RETURN_ON_ERROR(cap_mcp_server_register_tools(), TAG, "Failed to register MCP tools");
     return ESP_OK;
@@ -446,6 +573,28 @@ static esp_err_t cap_mcp_server_descriptor_stop(void)
     return ret;
 }
 
+static esp_err_t cap_mcp_server_save_reply_execute(const char *input_json,
+                                                    const claw_cap_call_context_t *ctx,
+                                                    char *output,
+                                                    size_t output_size)
+{
+    cJSON *root = cJSON_Parse(input_json ? input_json : "{}");
+    if (!root) {
+        snprintf(output, output_size, "Error: invalid JSON");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char *message = cJSON_GetStringValue(cJSON_GetObjectItem(root, "message"));
+    if (message && message[0]) {
+        cap_mcp_reply_buf_push(message);
+        ESP_LOGI(TAG, "mcp_save_reply: stored reply (len=%u)", (unsigned)strlen(message));
+    }
+
+    snprintf(output, output_size, "{\"ok\":true}");
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
 static const claw_cap_descriptor_t s_mcp_server_descriptors[] = {
     {
         .id = "mcp_server",
@@ -458,6 +607,17 @@ static const claw_cap_descriptor_t s_mcp_server_descriptors[] = {
         .init = cap_mcp_server_descriptor_init,
         .start = cap_mcp_server_descriptor_start,
         .stop = cap_mcp_server_descriptor_stop,
+    },
+    {
+        .id = "mcp_save_reply",
+        .name = "mcp_save_reply",
+        .family = "mcp",
+        .description = "Store agent reply text for retrieval via MCP agent.get_replies.",
+        .kind = CLAW_CAP_KIND_CALLABLE,
+        .execute = cap_mcp_server_save_reply_execute,
+        .input_schema_json = "{\"type\":\"object\",\"properties\":{"
+            "\"message\":{\"type\":\"string\"}"
+        "}}",
     },
 };
 

--- a/components/claw_capabilities/cap_mcp_server/src/cap_mcp_transport_http_auth.c
+++ b/components/claw_capabilities/cap_mcp_server/src/cap_mcp_transport_http_auth.c
@@ -1,0 +1,340 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cap_mcp_transport_http_auth.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_mcp_mgr.h"
+
+static const char *TAG = "cap_mcp_http_auth";
+
+#define CAP_MCP_HTTP_SESSION_ID_SIZE 48
+
+typedef struct esp_mcp_http_auth_item_s {
+    esp_mcp_mgr_handle_t handle;
+    httpd_handle_t httpd;
+    char *auth_token;
+    char session_id[CAP_MCP_HTTP_SESSION_ID_SIZE];
+} esp_mcp_http_auth_item_t;
+
+static void cap_mcp_http_auth_cleanup_item(esp_mcp_http_auth_item_t *item)
+{
+    if (!item) {
+        return;
+    }
+
+    if (item->auth_token) {
+        free(item->auth_token);
+        item->auth_token = NULL;
+    }
+}
+
+static bool cap_mcp_http_auth_header_matches(const httpd_req_t *req,
+                                             const char *header_name,
+                                             const char *expected_value)
+{
+    char value[160] = {0};
+
+    if (!req || !header_name || !expected_value || !expected_value[0]) {
+        return false;
+    }
+
+    if (httpd_req_get_hdr_value_str((httpd_req_t *)req, header_name, value, sizeof(value)) != ESP_OK) {
+        return false;
+    }
+
+    return strcmp(value, expected_value) == 0;
+}
+
+static bool cap_mcp_http_auth_is_authorized(httpd_req_t *req, const esp_mcp_http_auth_item_t *item)
+{
+    char bearer[192] = {0};
+
+    if (!item || !item->auth_token || !item->auth_token[0]) {
+        return true;
+    }
+
+    snprintf(bearer, sizeof(bearer), "Bearer %s", item->auth_token);
+    return cap_mcp_http_auth_header_matches(req, "Authorization", bearer);
+}
+
+static void cap_mcp_http_add_cors_headers(httpd_req_t *req)
+{
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "POST, OPTIONS");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Credentials", "false");
+}
+
+static esp_err_t cap_mcp_http_post_handler(httpd_req_t *req)
+{
+    esp_mcp_http_auth_item_t *mcp_http = NULL;
+    uint8_t *outbuf = NULL;
+    uint16_t outlen = 0;
+    int total_len;
+    int cur_len = 0;
+    int recv_len;
+    esp_err_t ret = ESP_OK;
+    char *mbuf = NULL;
+
+    ESP_RETURN_ON_FALSE(req, ESP_ERR_INVALID_ARG, TAG, "Invalid request");
+    ESP_RETURN_ON_FALSE(req->user_ctx, ESP_ERR_INVALID_ARG, TAG, "Invalid user context");
+
+    mcp_http = (esp_mcp_http_auth_item_t *)req->user_ctx;
+    ESP_LOGI(TAG, "HTTP %s %s len=%d", (req->method == HTTP_OPTIONS) ? "OPTIONS" : "POST", req->uri, req->content_len);
+
+    if (req->method == HTTP_OPTIONS) {
+        ESP_LOGI(TAG, "Responding to CORS preflight");
+        cap_mcp_http_add_cors_headers(req);
+        httpd_resp_set_status(req, HTTPD_204);
+        esp_err_t options_ret = httpd_resp_send(req, NULL, 0);
+        ESP_LOGI(TAG, "CORS preflight response: %s", esp_err_to_name(options_ret));
+        return options_ret;
+    }
+
+    if (!cap_mcp_http_auth_is_authorized(req, mcp_http)) {
+        ESP_LOGW(TAG, "Unauthorized request to %s", req->uri);
+        cap_mcp_http_add_cors_headers(req);
+        httpd_resp_set_status(req, "401 Unauthorized");
+        httpd_resp_send(req, NULL, 0);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "Authorized request; reading body");
+
+    total_len = req->content_len;
+    if (total_len < 0) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid content length");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    mbuf = calloc(1, total_len + 1);
+    ESP_RETURN_ON_FALSE(mbuf, ESP_ERR_NO_MEM, TAG, "Failed to allocate memory for message buffer");
+
+    while (cur_len < total_len) {
+        recv_len = httpd_req_recv(req, mbuf + cur_len, total_len - cur_len);
+        if (recv_len <= 0) {
+            ESP_LOGE(TAG, "Failed to receive request body: recv_len=%d cur_len=%d total_len=%d", recv_len, cur_len, total_len);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive data");
+            free(mbuf);
+            return ESP_FAIL;
+        }
+        cur_len += recv_len;
+    }
+    mbuf[total_len] = '\0';
+    ESP_LOGI(TAG, "Request body received (%d bytes)", total_len);
+
+    ret = esp_mcp_mgr_req_handle(mcp_http->handle, req->uri + 1, (const uint8_t *)mbuf, total_len, &outbuf, &outlen);
+    free(mbuf);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "MCP request failed: uri=%s err=%s", req->uri, esp_err_to_name(ret));
+        httpd_resp_set_status(req, "500 Internal Server Error");
+        httpd_resp_set_type(req, "text/plain");
+        httpd_resp_sendstr(req, esp_err_to_name(ret));
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "MCP request succeeded: outlen=%u", (unsigned)outlen);
+    httpd_resp_set_hdr(req, "Connection", "keep-alive");
+    httpd_resp_set_hdr(req, "Mcp-Session-Id", mcp_http->session_id);
+    httpd_resp_set_type(req, "application/json");
+    cap_mcp_http_add_cors_headers(req);
+    if (outbuf && outlen > 0) {
+        ESP_LOGI(TAG, "Sending JSON response");
+        ret = httpd_resp_send(req, (char *)outbuf, outlen);
+        esp_mcp_mgr_req_destroy_response(mcp_http->handle, outbuf);
+        return (ret == ESP_OK) ? ESP_OK : ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Sending empty response");
+    ret = httpd_resp_send(req, NULL, 0);
+    return (ret == ESP_OK) ? ESP_OK : ESP_FAIL;
+}
+
+static esp_err_t cap_mcp_http_server_init(esp_mcp_mgr_handle_t handle,
+                                          esp_mcp_transport_handle_t *transport_handle)
+{
+    esp_mcp_http_auth_item_t *item = NULL;
+
+    ESP_RETURN_ON_FALSE(transport_handle, ESP_ERR_INVALID_ARG, TAG, "Invalid transport handle pointer");
+
+    item = calloc(1, sizeof(esp_mcp_http_auth_item_t));
+    ESP_RETURN_ON_FALSE(item, ESP_ERR_NO_MEM, TAG, "Failed to allocate memory for HTTP item");
+
+    item->handle = handle;
+    snprintf(item->session_id, sizeof(item->session_id), "esp-claw-%p", (void *)item);
+    *transport_handle = (esp_mcp_transport_handle_t)item;
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_deinit(esp_mcp_transport_handle_t handle)
+{
+    esp_mcp_http_auth_item_t *item = (esp_mcp_http_auth_item_t *)handle;
+
+    ESP_RETURN_ON_FALSE(item, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+    cap_mcp_http_auth_cleanup_item(item);
+    item->handle = 0;
+    free(item);
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_create_config(const void *config, void **config_out)
+{
+    const cap_mcp_http_auth_config_t *in = NULL;
+    cap_mcp_http_auth_config_t *out = NULL;
+
+    ESP_RETURN_ON_FALSE(config && config_out, ESP_ERR_INVALID_ARG, TAG, "Invalid configuration");
+    in = (const cap_mcp_http_auth_config_t *)config;
+
+    out = calloc(1, sizeof(cap_mcp_http_auth_config_t));
+    ESP_RETURN_ON_FALSE(out, ESP_ERR_NO_MEM, TAG, "Failed to allocate memory for HTTP configuration");
+
+    out->http_config = in->http_config;
+    if (in->auth_token && in->auth_token[0]) {
+        out->auth_token = strdup(in->auth_token);
+        ESP_RETURN_ON_FALSE(out->auth_token, ESP_ERR_NO_MEM, TAG, "Failed to duplicate auth token");
+    }
+
+    *config_out = out;
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_delete_config(void *config)
+{
+    cap_mcp_http_auth_config_t *http_config = (cap_mcp_http_auth_config_t *)config;
+
+    ESP_RETURN_ON_FALSE(http_config, ESP_ERR_INVALID_ARG, TAG, "Invalid configuration");
+    if (http_config->auth_token) {
+        free((void *)http_config->auth_token);
+    }
+    free(http_config);
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_start(esp_mcp_transport_handle_t handle, void *config)
+{
+    esp_mcp_http_auth_item_t *item = (esp_mcp_http_auth_item_t *)handle;
+    cap_mcp_http_auth_config_t *http_config = (cap_mcp_http_auth_config_t *)config;
+
+    ESP_RETURN_ON_FALSE(item && http_config, ESP_ERR_INVALID_ARG, TAG, "Invalid args");
+    item->auth_token = http_config->auth_token ? strdup(http_config->auth_token) : NULL;
+    if (http_config->auth_token && !item->auth_token) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_err_t ret = httpd_start(&item->httpd, &http_config->http_config);
+    if (ret != ESP_OK) {
+        cap_mcp_http_auth_cleanup_item(item);
+        ESP_LOGE(TAG, "Failed to start HTTP server: %s", esp_err_to_name(ret));
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_stop(esp_mcp_transport_handle_t handle)
+{
+    esp_mcp_http_auth_item_t *item = (esp_mcp_http_auth_item_t *)handle;
+
+    ESP_RETURN_ON_FALSE(item, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+    if (item->httpd) {
+        esp_err_t ret = httpd_stop(item->httpd);
+        ESP_RETURN_ON_ERROR(ret, TAG, "HTTP server stop failed: %s", esp_err_to_name(ret));
+        item->httpd = NULL;
+    }
+
+    cap_mcp_http_auth_cleanup_item(item);
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_register_endpoint(esp_mcp_transport_handle_t handle,
+                                                       const char *ep_name,
+                                                       void *priv_data)
+{
+    esp_mcp_http_auth_item_t *item = (esp_mcp_http_auth_item_t *)handle;
+    size_t ep_uri_len;
+    char *ep_uri = NULL;
+    httpd_uri_t config_handler;
+    esp_err_t ret;
+
+    (void)priv_data;
+    ESP_RETURN_ON_FALSE(item && item->httpd, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+    ESP_RETURN_ON_FALSE(ep_name, ESP_ERR_INVALID_ARG, TAG, "Invalid endpoint name");
+
+    ep_uri_len = strlen(ep_name) + 2;
+    ep_uri = calloc(1, ep_uri_len);
+    ESP_RETURN_ON_FALSE(ep_uri, ESP_ERR_NO_MEM, TAG, "Malloc failed for ep uri");
+
+    snprintf(ep_uri, ep_uri_len, "/%s", ep_name);
+    config_handler = (httpd_uri_t){
+        .uri = ep_uri,
+        .method = HTTP_POST,
+        .handler = cap_mcp_http_post_handler,
+        .user_ctx = item,
+    };
+
+    ret = httpd_register_uri_handler(item->httpd, &config_handler);
+    free(ep_uri);
+    ESP_RETURN_ON_ERROR(ret, TAG, "Uri handler register failed: %s", esp_err_to_name(ret));
+
+    ep_uri = calloc(1, ep_uri_len);
+    ESP_RETURN_ON_FALSE(ep_uri, ESP_ERR_NO_MEM, TAG, "Malloc failed for ep uri");
+    snprintf(ep_uri, ep_uri_len, "/%s", ep_name);
+    config_handler = (httpd_uri_t){
+        .uri = ep_uri,
+        .method = HTTP_OPTIONS,
+        .handler = cap_mcp_http_post_handler,
+        .user_ctx = item,
+    };
+    ret = httpd_register_uri_handler(item->httpd, &config_handler);
+    free(ep_uri);
+    ESP_RETURN_ON_ERROR(ret, TAG, "Options handler register failed: %s", esp_err_to_name(ret));
+    return ESP_OK;
+}
+
+static esp_err_t cap_mcp_http_server_unregister_endpoint(esp_mcp_transport_handle_t handle,
+                                                         const char *ep_name)
+{
+    esp_mcp_http_auth_item_t *item = (esp_mcp_http_auth_item_t *)handle;
+    size_t ep_uri_len;
+    char *ep_uri = NULL;
+    esp_err_t ret;
+
+    ESP_RETURN_ON_FALSE(item && item->httpd, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+    ESP_RETURN_ON_FALSE(ep_name, ESP_ERR_INVALID_ARG, TAG, "Invalid endpoint name");
+
+    ep_uri_len = strlen(ep_name) + 2;
+    ep_uri = calloc(1, ep_uri_len);
+    ESP_RETURN_ON_FALSE(ep_uri, ESP_ERR_NO_MEM, TAG, "Malloc failed for ep uri");
+
+    snprintf(ep_uri, ep_uri_len, "/%s", ep_name);
+    ret = httpd_unregister_uri(item->httpd, ep_uri);
+    free(ep_uri);
+    ESP_RETURN_ON_ERROR(ret, TAG, "Uri handler unregister failed: %s", esp_err_to_name(ret));
+
+    ep_uri = calloc(1, ep_uri_len);
+    ESP_RETURN_ON_FALSE(ep_uri, ESP_ERR_NO_MEM, TAG, "Malloc failed for ep uri");
+    snprintf(ep_uri, ep_uri_len, "/%s", ep_name);
+    ret = httpd_unregister_uri(item->httpd, ep_uri);
+    free(ep_uri);
+    ESP_RETURN_ON_ERROR(ret, TAG, "Options handler unregister failed: %s", esp_err_to_name(ret));
+    return ESP_OK;
+}
+
+const esp_mcp_transport_t cap_mcp_transport_http_server_auth = {
+    .init = cap_mcp_http_server_init,
+    .deinit = cap_mcp_http_server_deinit,
+    .create_config = cap_mcp_http_server_create_config,
+    .delete_config = cap_mcp_http_server_delete_config,
+    .start = cap_mcp_http_server_start,
+    .stop = cap_mcp_http_server_stop,
+    .register_endpoint = cap_mcp_http_server_register_endpoint,
+    .unregister_endpoint = cap_mcp_http_server_unregister_endpoint,
+};

--- a/components/claw_capabilities/cap_mcp_server/src/cmd_cap_mcp_server.c
+++ b/components/claw_capabilities/cap_mcp_server/src/cmd_cap_mcp_server.c
@@ -22,6 +22,7 @@ static struct {
     struct arg_str *endpoint;
     struct arg_int *server_port;
     struct arg_int *ctrl_port;
+    struct arg_str *auth_token;
     struct arg_end *end;
 } mcp_server_args;
 
@@ -103,6 +104,7 @@ static int mcp_server_func(int argc, char **argv)
                          (uint16_t)mcp_server_args.server_port->ival[0] : 0;
     config.ctrl_port = mcp_server_args.ctrl_port->count ?
                        (uint16_t)mcp_server_args.ctrl_port->ival[0] : 0;
+    config.auth_token = mcp_server_args.auth_token->count ? mcp_server_args.auth_token->sval[0] : NULL;
 
     err = cap_mcp_server_set_config(&config);
     if (err != ESP_OK) {
@@ -125,7 +127,8 @@ void register_cap_mcp_server(void)
     mcp_server_args.endpoint = arg_str0(NULL, "endpoint", "<endpoint>", "HTTP endpoint path");
     mcp_server_args.server_port = arg_int0(NULL, "server-port", "<port>", "HTTP server port");
     mcp_server_args.ctrl_port = arg_int0(NULL, "ctrl-port", "<port>", "HTTP control port");
-    mcp_server_args.end = arg_end(8);
+    mcp_server_args.auth_token = arg_str0(NULL, "auth-token", "<token>", "Bearer token required for MCP requests");
+    mcp_server_args.end = arg_end(9);
 
     const esp_console_cmd_t mcp_server_cmd = {
         .command = "mcp_server",
@@ -133,6 +136,7 @@ void register_cap_mcp_server(void)
         "Examples:\n"
         " mcp_server --status\n"
         " mcp_server --set-config --hostname "CAP_MCP_SERVER_DEFAULT_HOSTNAME" --endpoint mcp_server\n"
+        " mcp_server --set-config --auth-token secret-token\n"
         " mcp_server --disable\n"
         " mcp_server --enable\n",
         .func = mcp_server_func,

--- a/components/common/app_claw/app_capabilities.c
+++ b/components/common/app_claw/app_capabilities.c
@@ -616,7 +616,7 @@ static const app_capability_group_info_t s_capability_group_infos[] = {
     { "cap_lua", "Lua", true },
 #endif
 #if CONFIG_APP_CLAW_CAP_MCP_CLIENT
-    { "cap_mcp_client", "MCP Client", false },
+    { "cap_mcp_client", "MCP Client", true },
 #endif
 #if CONFIG_APP_CLAW_CAP_MCP_SERVER
     { "cap_mcp_server", "MCP Server", false },


### PR DESCRIPTION
## 概述

MCP 客户端和服务器的多项改进，包括 Streamable HTTP 传输支持、并发请求处理、会话头兼容性增强。

## 变更内容

### MCP 客户端
- 新增 SSE 传输模块（`cap_mcp_client_sse.c/.h`）
- 兼容多会话头变体（`mcp-session-id`, `x-session-id`, `session-id`, `x-mcp-session`），大小写不敏感
- 会话错误时自动清理缓存并重试一次
- 添加诊断日志（`[DIAG]` 前缀），显示缓存的会话状态
- 响应缓冲区从 8KB 扩至 64KB，修复大响应时的堆损坏
- LLM 可见性开启（`llm_visible=true`）
- 默认端点从 `mcp_server` 改为 `mcp`（MCPHub 标准统一端点）
- 工具列表紧凑显示、UTF-8 安全截断

### MCP 服务器
- 新增回复缓冲区（`cap_mcp_reply_buf_t`），支持并发请求处理
- 互斥量保护的多响应缓存
- Tool 定义 property_names 数组空间扩展（7→9）

## 相关提交
- `2a90971` feat: MCP Client Streamable HTTP support and LLM visibility
- `b1c0d6e` fix(mcp-server): add reply buffer for concurrent request handling
- `2f807fe` fix(mcp-client): widen session header variants, add diag log, and one-time retry