### PR TITLE
cap_im_tg: bound accumulated Telegram HTTP response size

### DIFF
--- a/components/claw_capabilities/cap_im_platform/src/cap_im_tg.c
+++ b/components/claw_capabilities/cap_im_platform/src/cap_im_tg.c
@@ -128,12 +128,18 @@ static bool cap_im_tg_dedup_check_and_record(const char *update_key)
     return false;
 }
 
+#define CAP_IM_TG_MAX_RESP_SIZE (64U * 1024U)
+
 static esp_err_t cap_im_tg_http_event_handler(esp_http_client_event_t *event)
 {
     cap_im_tg_http_resp_t *resp = (cap_im_tg_http_resp_t *)event->user_data;
 
     if (!resp || event->event_id != HTTP_EVENT_ON_DATA || event->data_len <= 0) {
         return ESP_OK;
+    }
+
+    if (resp->len + (size_t)event->data_len + 1 > CAP_IM_TG_MAX_RESP_SIZE) {
+        return ESP_ERR_NO_MEM;
     }
 
     if (resp->len + (size_t)event->data_len + 1 > resp->cap) {


### PR DESCRIPTION
## Summary

Adds an upper bound for accumulated Telegram HTTP response data in `cap_im_tg_http_event_handler()`.

## Motivation

The current handler grows the response buffer as data arrives. Although the buffer is reallocated before `memcpy`, an unexpectedly large response can still cause excessive memory growth or OOM on memory-constrained ESP devices.

This change adds a maximum response size check before appending new data, causing oversized responses to fail explicitly instead of continuing to grow the buffer.

## Notes

This is defensive hardening / resource-exhaustion protection, not a direct heap buffer overflow fix. The previous description overstated the issue.

## Changes
- `components/claw_capabilities/cap_im_platform/src/cap_im_tg.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
