### PR TITLE
boards: Add support for Waveshare ESP32-S3-GEEK board

### DIFF
--- a/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_devices.yaml
+++ b/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_devices.yaml
@@ -1,0 +1,46 @@
+version: 1.0.0
+# Devices Configuration for Waveshare ESP32-S3-GEEK
+devices:
+
+  # On-board 1.14" ST7789 LCD (135x240, with 52/40 panel offset)
+  - name: display_lcd
+    chip: st7789
+    type: display_lcd
+    sub_type: spi
+    version: default
+    config:
+      mirror_x: true
+      mirror_y: true
+      swap_xy: false
+      invert_color: true
+      x_max: 135
+      y_max: 240
+      io_spi_config:
+        cs_gpio_num: 10          # LCD_CS
+        dc_gpio_num: 8           # LCD_DC
+        spi_mode: 0
+        pclk_hz: 40000000
+      lcd_panel_config:
+        reset_gpio_num: 9        # LCD_RST
+        data_endian: LCD_RGB_DATA_ENDIAN_BIG
+        vendor_config: NULL
+    peripherals:
+      - name: spi_display
+
+  # On-board TF card slot wired in SPI mode.
+  # In SPI mode the card signals map as:
+  #   D3(GPIO34)=CS, CMD(GPIO35)=MOSI, D0(GPIO37)=MISO, CLK(GPIO36)=SCK
+  - name: fs_sdcard
+    type: fs_fat
+    sub_type: spi
+    version: default
+    config:
+      mount_point: "/sdcard"
+      vfs_config:
+        format_if_mount_failed: false
+        max_files: 5
+        allocation_unit_size: 16384
+      sub_config:
+        cs_gpio_num: 34          # SD_CS (SDIO_D3)
+    peripherals:
+      - name: spi_sdcard

--- a/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_info.yaml
+++ b/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_info.yaml
@@ -1,0 +1,4 @@
+board: waveshare_esp32_s3_geek
+chip: esp32s3
+description: "Waveshare ESP32-S3-GEEK USB-A stick with 1.14in ST7789 240x135 IPS LCD and TF card slot"
+manufacturer: "Waveshare"

--- a/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_peripherals.yaml
+++ b/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/board_peripherals.yaml
@@ -1,0 +1,52 @@
+version: 1.0.0
+# Peripherals Configuration for Waveshare ESP32-S3-GEEK
+#
+# Pin reference (from schematic ESP32-S3-GEEK V1.1):
+#   LCD SPI:   CLK=GPIO12, MOSI=GPIO11, CS=GPIO10, DC=GPIO8, RST=GPIO9
+#   LCD BL:    GPIO7 → R2(1K) → SS8050(NPN) → LEDK  (active-HIGH)
+#   SD card:   SCK=GPIO36,  MOSI=GPIO35, MISO=GPIO37, CS=GPIO34
+#   I2C hdr:   SDA=GPIO16, SCL=GPIO17  (H1 connector, no onboard devices)
+#   UART hdr:  RXD=GPIO44, TXD=GPIO43  (H3 connector)
+#   GPIO hdr:  GPIO6, GPIO13, GPIO14   (H2 connector)
+#   BOOT btn:  GPIO0
+
+peripherals:
+
+  # SPI bus for the onboard 1.14" ST7789 LCD (write-only, no MISO).
+  # Uses SPI3_HOST to leave SPI2_HOST free for the TF card.
+  - name: spi_display
+    type: spi
+    role: master
+    config:
+      spi_bus_config:
+        spi_port: SPI3_HOST
+        data0_io_num: 11         # MOSI  (LCD_MOSI)
+        sclk_io_num: 12          # SCLK  (LCD_CLK)
+        max_transfer_sz: 5400    # ~1/12 frame (240*135*2/12 ≈ 5400 B) for DMA chunks
+
+  # SPI bus for the onboard TF (microSD) card slot (full-duplex).
+  # Uses SPI2_HOST on dedicated GPIO33-38 range.
+  - name: spi_sdcard
+    type: spi
+    role: master
+    config:
+      spi_bus_config:
+        spi_port: SPI2_HOST
+        mosi_io_num: 35          # SD_MOSI  (SDIO_CMD)
+        miso_io_num: 37          # SD_MISO  (SDIO_D0)
+        sclk_io_num: 36          # SD_SCK   (SDIO_SCK)
+        max_transfer_sz: 32768   # 32 KB — typical SD block multiple
+
+  # LCD backlight: GPIO7 drives SS8050 NPN transistor base (active-HIGH).
+  # Full duty (1023) on startup so the display is visible immediately;
+  # duty stays fixed — the board manager toggles the ST7789 disp_on_off
+  # command, not the PWM duty, to control on/off.
+  - name: ledc_backlight
+    type: ledc
+    role: none
+    config:
+      gpio_num: 7
+      freq_hz: 5000
+      duty: 1023
+      duty_resolution: LEDC_TIMER_10_BIT
+      output_invert: false

--- a/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/sdkconfig.defaults.board
+++ b/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/sdkconfig.defaults.board
@@ -1,0 +1,32 @@
+# Waveshare ESP32-S3-GEEK — ESP32-S3R2
+# 16 MB external QIO NOR flash (W25Q128) + 2 MB on-chip Quad PSRAM
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+
+# Partition table is auto-selected from partitions_16MB.csv
+# by tools/cmake/flash_partition_defaults.cmake.
+
+# On-chip 2 MB Quad PSRAM (R2 variant — not octal)
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_QUAD=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# Disable XIP-from-PSRAM: 2 MB is not enough to hold both flash instructions
+# (~1.5 MB) and rodata (~700 KB). Instructions are fetched from flash cache
+# instead (32 KB I-cache on ESP32-S3), with a small performance trade-off.
+CONFIG_SPIRAM_XIP_FROM_PSRAM=n
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
+CONFIG_SPIRAM_RODATA=n
+
+# Quad PSRAM cannot keep the stack accessible while cache is disabled for a flash
+# transaction. Force FreeRTOS to allocate task stacks from internal RAM so claw
+# tasks tagged CLAW_TASK_STACK_PREFER_PSRAM fall back to internal memory.
+CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n
+
+# USB: Serial JTAG
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+CONFIG_ESP_CONSOLE_SECONDARY_NONE=y
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED=y

--- a/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/setup_device.c
+++ b/application/edge_agent/boards/waveshare/waveshare_esp32_s3_geek/setup_device.c
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Waveshare ESP32-S3-GEEK — board-specific device factories.
+ * Provides the ST7789 panel factory used by the generic display_lcd device.
+ */
+#include <string.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_panel_ops.h"
+
+static const char *TAG = "WS_S3_GEEK_SETUP";
+
+/* Visible portion of the 1.14" 135x240 ST7789 panel starts at (52, 40). */
+#define GEEK_LCD_OFFSET_X  52
+#define GEEK_LCD_OFFSET_Y  40
+
+esp_err_t lcd_panel_factory_entry_t(esp_lcd_panel_io_handle_t io,
+                                    const esp_lcd_panel_dev_config_t *panel_dev_config,
+                                    esp_lcd_panel_handle_t *ret_panel)
+{
+    esp_lcd_panel_dev_config_t cfg = {0};
+    memcpy(&cfg, panel_dev_config, sizeof(esp_lcd_panel_dev_config_t));
+
+    esp_err_t ret = esp_lcd_new_panel_st7789(io, &cfg, ret_panel);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "esp_lcd_new_panel_st7789 failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = esp_lcd_panel_set_gap(*ret_panel, GEEK_LCD_OFFSET_X, GEEK_LCD_OFFSET_Y);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "esp_lcd_panel_set_gap failed: %s", esp_err_to_name(ret));
+    }
+    return ESP_OK;
+}


### PR DESCRIPTION
Add support for the ESP32-S3-GEEK board from Waveshare.

## Description

This board package follows the existing `esp_board_manager` YAML-driven pattern used by other supported boards.

The following hardware definitions were added:

Chip:
- ESP32-S3R2 — 16 MB QIO NOR flash, 2 MB on-chip Quad PSRAM, dual-core @240 MHz

Display
- 1.14" ST7789 IPS LCD, 135×240 resolution
- Connected via SPI3_HOST (write-only, no MISO): MOSI=GPIO11, CLK=GPIO12, CS=GPIO10, DC=GPIO8, RST=GPIO9
- Panel has a 52/40 pixel offset (the visible area doesn't start at (0,0) on the ST7789 framebuffer)
- Colors inverted, X-axis mirrored, 40 MHz SPI clock
- Backlight via GPIO7 → SS8050 NPN transistor (active-high PWM, LEDC @ 5 kHz, fixed at full duty)

Storage
- TF (microSD) card slot in SPI mode via SPI2_HOST: MOSI=GPIO35, MISO=GPIO37, CLK=GPIO36, CS=GPIO34
- Mounted at /sdcard as FAT, max 5 open files, 16 KB allocation units

Expansion headers (no onboard devices, just broken out)
- I2C: SDA=GPIO16, SCL=GPIO17 (H1)
- GPIO: GPIO6, GPIO13, GPIO14 (H2)
- UART: RX=GPIO44, TX=GPIO43 (H3)
- BOOT button: GPIO0

Since this board only has 2 MB of PSRAM, disable XIP from PSRAM, don't copy flash code segments into PSRAM, and don't copy read-only data into PSRAM.

## Related

N/A

## Testing


I validated that this project builds and flashes successfully. The board boots up to the agent loop. The Telegram bot and Brave search are functional. The agent is able to call the Lua API. The display renders the Lobster mascot correctly.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
