### PR TITLE
feat(board): 新增微雪 ESP32-P4-NANO 开发板 BSP 支持 + I2S 音频修复

### DIFF
--- a/application/edge_agent/boards/waveshare/esp32_p4_nano/board_peripherals.yaml
+++ b/application/edge_agent/boards/waveshare/esp32_p4_nano/board_peripherals.yaml
@@ -29,8 +29,8 @@ peripherals:
         mclk: 13
         bclk: 12
         ws: 10
-        dout: 11
-        din: 9
+        dout: 9
+        din: 11
 
   # I2S Audio Input for ES8311 codec
   - name: i2s_audio_in
@@ -50,8 +50,8 @@ peripherals:
         mclk: 13
         bclk: 12
         ws: 10
-        dout: 11
-        din: 9
+        dout: 9
+        din: 11
 
   # PA Control GPIO
   - name: gpio_pa_control


### PR DESCRIPTION
## 变更内容

### 新增微雪 ESP32-P4-NANO 开发板支持
- 完整 BSP 配置：`boards/waveshare/esp32_p4_nano/`
  - `board_info.yaml` - 板级信息
  - `board_devices.yaml` - 设备树配置
  - `board_peripherals.yaml` - 外设引脚配置
  - `sdkconfig.defaults.board` - 板级默认配置
  - `setup_device.c` - 板级初始化

### 硬件外设
- **音频**: ES8311 编解码器 + NS4150B D 类功放
- **I2S**: 标准模式 48kHz/16bit/双声道
  - WS: GPIO 10, BCLK: GPIO 12
  - DOUT: GPIO 9 (数据输出到扬声器)
  - DIN: GPIO 11 (麦克风输入)
- **功放控制**: GPIO 53
- **SD 卡**: SDMMC 4-bit 模式
- **LCD 背光**: LEDC PWM GPIO 20

### I2S 引脚修复
修正了 I2S DOUT/DIN 引脚交换问题（原配置 dout=11, din=9 导致扬声器无声），已上机测试验证：
- ✅ 音频播放正常
- ✅ 录音功能正常  
- ✅ 回放功能正常

### 测试环境
- 硬件: ESP32-P4-NANO (微雪)
- ESP-IDF: v5.5.4
- 串口: COM14, 115200bps