### PR TITLE
feat(board): add Wireless Tag WT32-SC01 Plus (ESP32-S3, ST7796 I80)

### DIFF
--- a/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_devices.yaml
+++ b/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_devices.yaml
@@ -1,0 +1,97 @@
+version: 1.0.0
+# Devices Configuration for Wireless Tag WT32-SC01 Plus
+#
+# LCD: ST7796UI 480×320, 8-bit Intel 8080 parallel bus (SOC_LCD_I80_SUPPORTED)
+#   DC/RS: GPIO0   WR: GPIO47   DB[0..7]: GPIO9,46,3,8,18,17,16,15
+#   All hardware init done in setup_device.c (type: custom)
+#
+# Touch: FT6336U capacitive, ft5x06-compatible, over I2C
+#   SDA: GPIO6   SCL: GPIO5   INT: GPIO7   Shared reset: GPIO4
+#
+# SD Card: SPI mode on SPI2_HOST
+#   MOSI: GPIO40   MISO: GPIO38   SCK: GPIO39   CS: GPIO41
+#
+# CAN Bus (TWAI): TX: GPIO10   RX: GPIO11  (adjust to your wiring)
+
+devices:
+
+  # ── LCD display (ST7796UI, 480×320, 8-bit I80 parallel) ──────────────────
+  # ESP32-S3 has SOC_LCD_I80_SUPPORTED but no PARLIO, so the native I80 bus
+  # is used. All init (bus, panel IO, ST7796) lives in setup_device.c.
+  - name: display_lcd
+    chip: st7796
+    type: custom
+    version: default
+    dependencies:
+      espressif/esp_lcd_st7796: "^1.3.0"
+    config:
+      lcd_width: 480
+      lcd_height: 320
+
+  # ── Touch panel (FT6336U / ft5x06-compatible, I2C 0x38) ─────────────────
+  - name: lcd_touch
+    chip: ft5x06
+    type: lcd_touch
+    sub_type: i2c
+    version: default
+    dependencies:
+      esp_lcd_touch:
+        version: "*"
+        require: public
+      espressif/esp_lcd_touch_ft5x06: "^1.0.7"
+    config:
+      io_i2c_config:
+        lcd_cmd_bits: 8
+        scl_speed_hz: 400000
+        flags:
+          dc_low_on_data: false
+          disable_control_phase: true
+      touch_config:
+        x_max: 320
+        y_max: 480
+        rst_gpio_num: -1        # reset shared with LCD, handled in setup_device.c
+        int_gpio_num: 7
+        levels:
+          reset: 0
+          interrupt: 0
+        flags:
+          swap_xy: true
+          mirror_x: false
+          mirror_y: false
+    peripherals:
+      - name: i2c_master
+        i2c_addr: [0x70]        # FT6336U 7-bit 0x38 in 8-bit format (0x38 << 1)
+
+  # ── SD Card (SPI mode) ───────────────────────────────────────────────────
+  - name: fs_sdcard
+    type: fs_fat
+    sub_type: spi
+    version: default
+    init_skip: true
+    config:
+      sub_config:
+        cs_gpio_num: 41
+        frequency: SDMMC_FREQ_DEFAULT
+    peripherals:
+      - name: spi_master
+
+  # ── LCD backlight (LEDC PWM on GPIO45) ──────────────────────────────────
+  - name: lcd_brightness
+    type: ledc_ctrl
+    version: default
+    config:
+      default_percent: 100
+    peripherals:
+      - name: ledc_backlight
+
+  # ── CAN Bus (TWAI) — managed by lua_driver_canbus ────────────────────────
+  - name: can_bus
+    chip: twai
+    type: custom
+    version: default
+    init_skip: true
+    config:
+      tx_gpio: 10
+      rx_gpio: 11
+      bitrate: 500000
+      mode: normal

--- a/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_info.yaml
+++ b/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_info.yaml
@@ -1,0 +1,5 @@
+board: esp32s3_wt32_sc01_plus
+chip: esp32s3
+version: 1.0.0
+description: "Wireless Tag WT32-SC01 Plus Smart Panel with 3.5-inch ST7796 IPS LCD and FT5x06 touch"
+manufacturer: "Wireless Tag"

--- a/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_peripherals.yaml
+++ b/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/board_peripherals.yaml
@@ -1,0 +1,47 @@
+version: 1.0.0
+# Peripherals Configuration for Wireless Tag WT32-SC01 Plus
+#
+# LCD: ST7796 (480x320), 8-bit Intel 8080 parallel bus (SOC_LCD_I80_SUPPORTED)
+#   DC/RS: GPIO0   WR: GPIO47   DB[0..7]: GPIO9,46,3,8,18,17,16,15
+#   Shared reset (LCD + touch): GPIO4   Backlight: GPIO45 (LEDC)
+#
+# Touch: FT6336U capacitive controller over I2C
+#   SDA: GPIO6   SCL: GPIO5   INT: GPIO7
+#
+# SD Card: SPI mode
+#   MOSI: GPIO40   MISO: GPIO38   SCK: GPIO39   CS: GPIO41
+#
+# CAN Bus (TWAI): TX: GPIO10   RX: GPIO11
+
+peripherals:
+  # I2C bus — touch controller FT6336U (0x38)
+  - name: i2c_master
+    type: i2c
+    role: master
+    config:
+      port: 0
+      pins:
+        sda: 6
+        scl: 5
+
+  # SPI bus — SD card
+  - name: spi_master
+    type: spi
+    role: master
+    config:
+      spi_bus_config:
+        spi_port: SPI2_HOST
+        mosi_io_num: 40
+        miso_io_num: 38
+        sclk_io_num: 39
+        max_transfer_sz: 4092
+
+  # LCD backlight — LEDC PWM on GPIO45
+  - name: ledc_backlight
+    type: ledc
+    role: none
+    config:
+      gpio_num: 45
+      freq_hz: 5000
+      duty: 0
+      duty_resolution: LEDC_TIMER_10_BIT

--- a/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/sdkconfig.defaults.board
+++ b/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/sdkconfig.defaults.board
@@ -1,0 +1,51 @@
+# Wireless Tag WT32-SC01 Plus board defaults
+# SoC: ESP32-S3-WROOM-1-N8R2 (8 MB QIO Flash, 2 MB Quad PSRAM)
+# LCD: ST7796 480x320 via native I80 bus (SOC_LCD_I80_SUPPORTED)
+# Touch: FT6336U via I2C (lcd_touch + sub_type: i2c)
+#
+# Note: if your module is N16R8 (16 MB flash, 8 MB Octal PSRAM), replace:
+#   CONFIG_ESPTOOLPY_FLASHSIZE_8MB -> _16MB
+#   CONFIG_SPIRAM_MODE_QUAD        -> CONFIG_SPIRAM_MODE_OCT
+
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# Flash: 8 MB QIO 80 MHz
+CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_16MB.csv"
+
+# Quad PSRAM 2 MB 80 MHz
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_QUAD=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# Disable XIP-from-PSRAM: the global default enables it, but 2 MB PSRAM is not
+# large enough to hold flash instructions + heap simultaneously.
+# Code executes directly from flash cache instead.
+CONFIG_SPIRAM_XIP_FROM_PSRAM=n
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=n
+CONFIG_SPIRAM_RODATA=n
+
+# With XIP-from-PSRAM disabled, disabling the SPI flash cache (needed for
+# any flash write: NVS, SPIFFS, OTA, …) also makes PSRAM inaccessible.
+# If a task's stack is in PSRAM the CPU panics with
+#   "assert failed: esp_task_stack_is_sane_cache_disabled"
+#
+# The global defaults set SPIRAM_MALLOC_ALWAYSINTERNAL=0 (all malloc can go to
+# PSRAM) and FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=y (PSRAM stacks allowed).
+# Both settings assume XIP-from-PSRAM is active.  Override them here:
+#   ALWAYSINTERNAL=65536 → every alloc < 64 kB stays in internal DRAM,
+#                          which covers all task stacks.
+#   TASK_CREATE_ALLOW_EXT_MEM=n → FreeRTOS refuses to start a task whose
+#                          stack landed in PSRAM (fail fast at creation).
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=65536
+CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n
+
+# Enable LCD display (custom I80 device in setup_device.c)
+CONFIG_ESP_BOARD_DEV_DISPLAY_LCD_SUPPORT=y
+
+# Enable capacitive touch (FT6336U via lcd_touch + sub_type: i2c)
+CONFIG_ESP_BOARD_DEV_LCD_TOUCH_SUPPORT=y
+CONFIG_ESP_BOARD_DEV_LCD_TOUCH_SUB_I2C_SUPPORT=y

--- a/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/setup_device.c
+++ b/application/edge_agent/boards/Wireless-Tag/esp32s3_wt32_sc01_plus/setup_device.c
@@ -1,0 +1,222 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file setup_device.c
+ * @brief Wireless Tag WT32-SC01 Plus board device initialisation.
+ *
+ * Display: ST7796UI, 480×320, 8-bit Intel 8080 parallel bus.
+ *   ESP32-S3 has SOC_LCD_I80_SUPPORTED but NOT PARLIO, so the native I80
+ *   driver (esp_lcd_new_i80_bus / esp_lcd_new_panel_io_i80) is used.
+ *
+ *   DC/RS : GPIO0    WR  : GPIO47
+ *   DB[0] : GPIO9    DB[1]: GPIO46   DB[2]: GPIO3    DB[3]: GPIO8
+ *   DB[4] : GPIO18   DB[5]: GPIO17   DB[6]: GPIO16   DB[7]: GPIO15
+ *
+ * Touch: FT6336U capacitive, ft5x06-compatible, over I2C.
+ *   SDA: GPIO6   SCL: GPIO5   INT: GPIO7
+ *
+ * Shared HW reset on GPIO4 — asserted once before either device is started;
+ * both device configs set reset_gpio_num = -1 / need_reset = false.
+ */
+
+#include <string.h>
+#include "driver/gpio.h"
+#include "esp_board_device.h"
+#include "esp_check.h"
+#include "esp_err.h"
+#include "esp_lcd_io_i80.h"
+#include "esp_lcd_panel_dev.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_st7796.h"
+#include "esp_lcd_touch_ft5x06.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "gen_board_device_custom.h"
+
+typedef struct {
+    esp_lcd_panel_io_handle_t io_handle;
+    esp_lcd_panel_handle_t    panel_handle;
+} wt32_lcd_handles_t;
+
+static const char *TAG = "wt32_sc01_plus";
+
+/* ── Pin assignments ─────────────────────────────────────────────────────── */
+#define LCD_DC_GPIO   0
+#define LCD_WR_GPIO   47
+#define LCD_RST_GPIO  4     /* shared with touch */
+#define LCD_CS_GPIO   (-1)  /* no CS; bus exclusively owned */
+
+static const gpio_num_t LCD_DATA_GPIOS[8] = {9, 46, 3, 8, 18, 17, 16, 15};
+
+/* ── Display geometry ────────────────────────────────────────────────────── */
+#define LCD_WIDTH   480
+#define LCD_HEIGHT  320
+
+/* ── I80 bus parameters ──────────────────────────────────────────────────── */
+#define LCD_PCLK_HZ        (10 * 1000 * 1000)
+#define LCD_MAX_TRANS_BYTES (LCD_WIDTH * LCD_HEIGHT * 2)  /* 16 bpp full frame */
+#define LCD_DMA_BURST_SIZE  64
+
+/* ── Shared reset ────────────────────────────────────────────────────────── */
+static bool s_reset_done = false;
+
+static void do_shared_reset(void)
+{
+    if (s_reset_done) {
+        return;
+    }
+    gpio_config_t cfg = {
+        .mode         = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = BIT64(LCD_RST_GPIO),
+    };
+    gpio_config(&cfg);
+    gpio_set_level(LCD_RST_GPIO, 0);
+    esp_rom_delay_us(20000);
+    gpio_set_level(LCD_RST_GPIO, 1);
+    esp_rom_delay_us(20000);
+    s_reset_done = true;
+    ESP_LOGI(TAG, "Shared HW reset on GPIO%d done", LCD_RST_GPIO);
+}
+
+/* ── Config exposed to esp_board_manager (custom device) ─────────────────── */
+static const dev_custom_display_lcd_config_t s_lcd_config = {
+    .name       = "display_lcd",
+    .type       = "custom",
+    .chip       = "st7796",
+    .lcd_width  = LCD_WIDTH,
+    .lcd_height = LCD_HEIGHT,
+};
+
+static wt32_lcd_handles_t s_lcd_handles;
+
+/* ── Custom display init ─────────────────────────────────────────────────── */
+static int display_lcd_init(void *config, int cfg_size, void **device_handle)
+{
+    (void)config;
+    (void)cfg_size;
+    ESP_RETURN_ON_FALSE(device_handle, ESP_ERR_INVALID_ARG, TAG, "device_handle is NULL");
+
+    do_shared_reset();
+
+    esp_err_t ret;
+
+    /* 1. Create I80 bus */
+    esp_lcd_i80_bus_config_t bus_cfg = {
+        .dc_gpio_num        = LCD_DC_GPIO,
+        .wr_gpio_num        = LCD_WR_GPIO,
+        .clk_src            = LCD_CLK_SRC_DEFAULT,
+        .bus_width          = 8,
+        .max_transfer_bytes = LCD_MAX_TRANS_BYTES,
+        .dma_burst_size     = LCD_DMA_BURST_SIZE,
+    };
+    for (int i = 0; i < 8; i++) {
+        bus_cfg.data_gpio_nums[i] = LCD_DATA_GPIOS[i];
+    }
+
+    esp_lcd_i80_bus_handle_t i80_bus = NULL;
+    ret = esp_lcd_new_i80_bus(&bus_cfg, &i80_bus);
+    ESP_RETURN_ON_ERROR(ret, TAG, "I80 bus init failed");
+
+    /* 2. Create panel IO */
+    esp_lcd_panel_io_i80_config_t io_cfg = {
+        .cs_gpio_num      = LCD_CS_GPIO,
+        .pclk_hz          = LCD_PCLK_HZ,
+        .trans_queue_depth= 10,
+        .lcd_cmd_bits     = 8,
+        .lcd_param_bits   = 8,
+        .dc_levels = {
+            .dc_idle_level  = 0,
+            .dc_cmd_level   = 0,
+            .dc_dummy_level = 0,
+            .dc_data_level  = 1,
+        },
+        .flags = {
+            .cs_active_high  = false,
+            .swap_color_bytes = false,
+        },
+    };
+
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    ret = esp_lcd_new_panel_io_i80(i80_bus, &io_cfg, &io_handle);
+    ESP_GOTO_ON_ERROR(ret, err_del_bus, TAG, "panel IO init failed");
+
+    /* 3. Create ST7796 panel */
+    esp_lcd_panel_dev_config_t panel_cfg = {
+        .reset_gpio_num  = -1,          /* reset already done via do_shared_reset() */
+        .rgb_ele_order   = LCD_RGB_ELEMENT_ORDER_BGR,
+        .data_endian     = LCD_RGB_DATA_ENDIAN_BIG,
+        .bits_per_pixel  = 16,
+        .flags = { .reset_active_high = false },
+        .vendor_config   = NULL,
+    };
+
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    ret = esp_lcd_new_panel_st7796(io_handle, &panel_cfg, &panel_handle);
+    ESP_GOTO_ON_ERROR(ret, err_del_io, TAG, "ST7796 panel init failed");
+
+    /* 4. Init panel and apply orientation */
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_init(panel_handle),
+                      err_del_panel, TAG, "panel init failed");
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_invert_color(panel_handle, true),
+                      err_del_panel, TAG, "invert color failed");
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_swap_xy(panel_handle, true),
+                      err_del_panel, TAG, "swap XY failed");
+    ESP_GOTO_ON_ERROR(esp_lcd_panel_disp_on_off(panel_handle, true),
+                      err_del_panel, TAG, "display on failed");
+
+    /* 5. Register with esp_board_manager */
+    s_lcd_handles.io_handle    = io_handle;
+    s_lcd_handles.panel_handle = panel_handle;
+    esp_board_device_override_config("display_lcd", &s_lcd_config, sizeof(s_lcd_config));
+    *device_handle = &s_lcd_handles;
+
+    ESP_LOGI(TAG, "ST7796 ready (%dx%d @ %lu MHz)",
+             LCD_WIDTH, LCD_HEIGHT, (unsigned long)(LCD_PCLK_HZ / 1000000));
+    return ESP_OK;
+
+err_del_panel:
+    esp_lcd_panel_del(panel_handle);
+err_del_io:
+    esp_lcd_panel_io_del(io_handle);
+err_del_bus:
+    esp_lcd_del_i80_bus(i80_bus);
+    return ret;
+}
+
+static int display_lcd_deinit(void *device_handle)
+{
+    wt32_lcd_handles_t *handles = (wt32_lcd_handles_t *)device_handle;
+    if (handles) {
+        if (handles->panel_handle) {
+            esp_lcd_panel_del(handles->panel_handle);
+            handles->panel_handle = NULL;
+        }
+        if (handles->io_handle) {
+            esp_lcd_panel_io_del(handles->io_handle);
+            handles->io_handle = NULL;
+        }
+    }
+    return ESP_OK;
+}
+
+CUSTOM_DEVICE_IMPLEMENT(display_lcd, display_lcd_init, display_lcd_deinit);
+
+/* ── Touch factory (used by lcd_touch_i2c device type) ──────────────────── */
+esp_err_t lcd_touch_factory_entry_t(esp_lcd_panel_io_handle_t io,
+                                    const esp_lcd_touch_config_t *touch_dev_config,
+                                    esp_lcd_touch_handle_t *ret_touch)
+{
+    do_shared_reset();
+    esp_err_t ret = esp_lcd_touch_new_i2c_ft5x06(io, touch_dev_config, ret_touch);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "ft5x06 init failed: %s", esp_err_to_name(ret));
+    }
+    return ret;
+}


### PR DESCRIPTION
## Summary

Adds board support for the **Wireless Tag WT32-SC01 Plus**:
- ESP32-S3 SoC, 16 MB flash, 2 MB Quad PSRAM
- ST7796 480×320 display via native 8-bit Intel 8080 (I80) bus
- FT6336U capacitive touch controller via I2C

## Files

| File | Purpose |
|------|---------|
| `board_peripherals.yaml` | I80 LCD bus + I2C bus definitions |
| `board_devices.yaml` | ST7796 LCD panel + FT6336U touch device |
| `sdkconfig.defaults.board` | PSRAM / stack constraints (see below) |
| `setup_device.c` | ST7796 init sequence via `esp_lcd` I80 driver |

## Key decisions

**Touch device type**: Uses `type: lcd_touch` / `sub_type: i2c` (not the deprecated `lcd_touch_i2c`). The deprecated type has a YAML mapping bug where `i2c_addr[]` is never populated from `io_i2c_config.dev_addr`, causing the probe loop to always target address 0x00 → `ESP_ERR_INVALID_RESPONSE` → reboot loop. Tracked in issue #90.

**PSRAM constraints**: The WT32-SC01 Plus has 2 MB Quad PSRAM, which is too small for `SPIRAM_XIP_FROM_PSRAM`. With XIP-from-PSRAM disabled, task stacks must remain in internal DRAM — otherwise any flash read while a task runs on a PSRAM stack triggers `esp_task_stack_is_sane_cache_disabled()` → panic. Tracked in issue #91.

```
CONFIG_SPIRAM_XIP_FROM_PSRAM=n
CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=65536
CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=n
```

## Test plan
- [ ] Board boots without reboot loop
- [ ] Display initialises and renders correctly
- [ ] Touch input registers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)