### PR TITLE
fix(wifi): support open STA network and improve diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ChangeLog
 
+## 2026-06-04
+
+### Fix:
+
+* Wi-Fi: fixed open-network STA connection by selecting `WIFI_AUTH_OPEN` when `wifi_password` is empty, instead of always requiring WPA2.
+* Wi-Fi: validated STA SSID/password length in both app config validation and wifi manager validation, preventing silent truncation and invalid runtime apply.
+* Wi-Fi: improved connection result semantics by distinguishing retry-exhausted failure from timeout in `wifi_manager_wait_connected` and startup wait handling.
+* Wi-Fi: added startup/connection observability logs (sanitized config summary, disconnect reason/retry context, and fallback details) to speed up field diagnostics.
+
 ## 2026-05-19
 
 ### Feature:
@@ -68,11 +77,11 @@
 
 ### Feature:
 
-* Stablized the system prompt:
+* Stabilized the system prompt:
   * `activate_skill` now accepts one `skill_id` per call and returns the full Skill markdown document in a `<skill_content>` tool result.
   * Removed automatic active Skill document prompt injection and the `deactivate_skill` flow.
   * Removed time context and part of session context from system prompt to keep it stable.
-  * Removed lua async job infomation from system prompt.
+  * Removed lua async job information from system prompt.
 
 ## 2026-05-08
 

--- a/application/edge_agent/components/app_config/app_config.c
+++ b/application/edge_agent/components/app_config/app_config.c
@@ -506,6 +506,21 @@ esp_err_t app_config_validate_wifi(const app_config_t *config, const char **mess
         }
         return ESP_ERR_INVALID_ARG;
     }
+    if (config->wifi_ssid[0] != '\0' && strlen(config->wifi_ssid) >= 32) {
+        if (message) {
+            *message = "wifi_ssid must be 1-31 characters";
+        }
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (config->wifi_password[0] != '\0') {
+        size_t wifi_password_len = strlen(config->wifi_password);
+        if (wifi_password_len < 8 || wifi_password_len > 63) {
+            if (message) {
+                *message = "wifi_password must be empty or 8-63 characters";
+            }
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
     if (config->ap_password[0] != '\0') {
         size_t ap_password_len = strlen(config->ap_password);
         if (ap_password_len < 8 || ap_password_len > 63) {

--- a/application/edge_agent/main/main.c
+++ b/application/edge_agent/main/main.c
@@ -59,6 +59,20 @@ static void app_free_runtime_state(void)
     s_config = NULL;
 }
 
+static void log_wifi_startup_config(const app_config_t *config)
+{
+    ESP_LOGI(TAG,
+             "Wi-Fi startup STA: ssid=%s pwd_len=%u",
+             config->wifi_ssid[0] ? config->wifi_ssid : "(empty)",
+             (unsigned)strlen(config->wifi_password));
+
+    ESP_LOGI(TAG,
+             "Wi-Fi startup AP: ssid=%s pwd_len=%u behavior=%s",
+             config->ap_ssid[0] ? config->ap_ssid : "(auto:mac-suffix)",
+             (unsigned)strlen(config->ap_password),
+             config->ap_behavior[0] ? config->ap_behavior : "keep");
+}
+
 static void on_wifi_state_changed(bool connected, void *user_ctx)
 {
     (void)user_ctx;
@@ -274,6 +288,8 @@ void app_main(void)
     }));
     ESP_ERROR_CHECK(wifi_manager_register_state_callback(on_wifi_state_changed, NULL));
 
+    log_wifi_startup_config(s_config);
+
     esp_err_t wifi_err = wifi_manager_start(&(wifi_manager_config_t) {
         .sta_ssid = s_config->wifi_ssid,
         .sta_password = s_config->wifi_password,
@@ -293,12 +309,29 @@ void app_main(void)
         }
 
         if (s_config->wifi_ssid[0] != '\0') {
-            if (wifi_manager_wait_connected(30000) == ESP_OK) {
+            esp_err_t wait_err = wifi_manager_wait_connected(30000);
+            if (wait_err == ESP_OK) {
                 wifi_manager_status_t status = {0};
                 wifi_manager_get_status(&status);
                 ESP_LOGI(TAG, "Wi-Fi STA ready: %s", status.sta_ip);
+            } else if (wait_err == ESP_FAIL) {
+                wifi_manager_status_t status = {0};
+                wifi_manager_get_status(&status);
+                ESP_LOGW(TAG,
+                         "Wi-Fi STA failed after retries: mode=%s ap_active=%d ap_ip=%s",
+                         status.mode ? status.mode : "off",
+                         status.ap_active,
+                         status.ap_ip ? status.ap_ip : "0.0.0.0");
+            } else if (wait_err == ESP_ERR_TIMEOUT) {
+                wifi_manager_status_t status = {0};
+                wifi_manager_get_status(&status);
+                ESP_LOGW(TAG,
+                         "Wi-Fi STA wait timeout: mode=%s ap_active=%d sta_configured=%d",
+                         status.mode ? status.mode : "off",
+                         status.ap_active,
+                         status.sta_configured);
             } else {
-                ESP_LOGW(TAG, "STA could not connect, dropped to AP fallback");
+                ESP_LOGW(TAG, "Wi-Fi STA wait returned error: %s", esp_err_to_name(wait_err));
             }
         }
 

--- a/components/common/wifi_manager/wifi_manager.c
+++ b/components/common/wifi_manager/wifi_manager.c
@@ -141,6 +141,11 @@ static uint32_t wifi_manager_max_retry(void)
     return s_config.max_retry ? s_config.max_retry : CONFIG_APP_WIFI_MAX_RETRY;
 }
 
+static bool wifi_manager_sta_password_is_set(void)
+{
+    return s_config.sta_password && s_config.sta_password[0] != '\0';
+}
+
 static void compose_ap_ssid(void)
 {
     if (s_config.ap_ssid && s_config.ap_ssid[0] != '\0') {
@@ -197,6 +202,18 @@ esp_err_t wifi_manager_validate_config(const wifi_manager_config_t *config)
     if (!config) {
         return ESP_ERR_INVALID_ARG;
     }
+    if (config->sta_ssid && config->sta_ssid[0] != '\0') {
+        size_t sta_ssid_len = strlen(config->sta_ssid);
+        if (sta_ssid_len >= sizeof(((wifi_config_t *)0)->sta.ssid)) {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+    if (config->sta_password && config->sta_password[0] != '\0') {
+        size_t sta_password_len = strlen(config->sta_password);
+        if (sta_password_len < 8 || sta_password_len >= sizeof(((wifi_config_t *)0)->sta.password)) {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
     if (config->ap_password && config->ap_password[0] != '\0') {
         size_t ap_password_len = strlen(config->ap_password);
         if (ap_password_len < 8 || ap_password_len >= sizeof(((wifi_config_t *)0)->ap.password)) {
@@ -229,6 +246,13 @@ static esp_err_t configure_sta_mode(const wifi_manager_config_t *config)
     sync_owned_config(config);
     compose_ap_ssid();
     s_sta_configured = (s_config.sta_ssid && s_config.sta_ssid[0] != '\0');
+    ESP_LOGI(TAG,
+             "Applying Wi-Fi config: sta_configured=%d sta_ssid_len=%u sta_password_empty=%d ap_password_empty=%d ap_behavior=%s",
+             s_sta_configured,
+             (unsigned)(s_config.sta_ssid ? strlen(s_config.sta_ssid) : 0U),
+             wifi_manager_sta_password_is_set() ? 0 : 1,
+             (s_config.ap_password && s_config.ap_password[0] != '\0') ? 0 : 1,
+             s_config.ap_behavior ? s_config.ap_behavior : "keep");
     if (s_reconnect_timer) {
         esp_timer_stop(s_reconnect_timer);
     }
@@ -240,7 +264,10 @@ static esp_err_t configure_sta_mode(const wifi_manager_config_t *config)
         strlcpy((char *)sta_cfg.sta.password,
                 s_config.sta_password ? s_config.sta_password : "",
                 sizeof(sta_cfg.sta.password));
-        sta_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+        sta_cfg.sta.threshold.authmode =
+            wifi_manager_sta_password_is_set()
+            ? WIFI_AUTH_WPA2_PSK
+            : WIFI_AUTH_OPEN;
         sta_cfg.sta.pmf_cfg.capable = true;
         sta_cfg.sta.pmf_cfg.required = false;
 
@@ -278,6 +305,11 @@ static void wifi_event_handler(void *arg,
         switch (event_id) {
         case WIFI_EVENT_STA_START:
             if (s_sta_configured) {
+                ESP_LOGI(TAG,
+                         "STA start: ssid_len=%u auth_threshold=%s mode=%s",
+                         (unsigned)strlen(s_config.sta_ssid),
+                         wifi_manager_sta_password_is_set() ? "wpa2_psk" : "open",
+                         wifi_manager_mode_string(s_mode));
                 esp_wifi_connect();
             } else {
                 ESP_LOGW(TAG, "Wi-Fi STA not configured, skipping connection");
@@ -285,12 +317,17 @@ static void wifi_event_handler(void *arg,
             return;
 
         case WIFI_EVENT_STA_DISCONNECTED:
+        {
+            const wifi_event_sta_disconnected_t *disc =
+                event_data ? (const wifi_event_sta_disconnected_t *)event_data : NULL;
+            uint16_t reason = disc ? disc->reason : 0;
             strlcpy(s_ip_addr, "0.0.0.0", sizeof(s_ip_addr));
             if (s_connected) {
                 s_connected = false;
                 notify_state_changed(false);
             }
             if (!s_sta_configured) {
+                ESP_LOGW(TAG, "STA disconnected but not configured, reason=%u", (unsigned)reason);
                 return;
             }
             if (s_retry_count < (int)wifi_manager_max_retry()) {
@@ -300,8 +337,14 @@ static void wifi_event_handler(void *arg,
                 }
                 s_retry_count++;
                 s_mode = s_ap_active ? WIFI_MODE_APSTA_TRYING : s_mode;
-                ESP_LOGI(TAG, "STA disconnected, retry %d/%" PRIu32 " in %" PRIu32 "ms",
-                         s_retry_count, wifi_manager_max_retry(), delay_ms);
+                ESP_LOGI(TAG,
+                         "STA disconnected: reason=%u retry=%d/%" PRIu32 " delay_ms=%" PRIu32 " mode=%s ap_active=%d",
+                         (unsigned)reason,
+                         s_retry_count,
+                         wifi_manager_max_retry(),
+                         delay_ms,
+                         wifi_manager_mode_string(s_mode),
+                         s_ap_active);
                 if (s_reconnect_timer) {
                     esp_timer_stop(s_reconnect_timer);
                     esp_timer_start_once(s_reconnect_timer, (uint64_t)delay_ms * 1000ULL);
@@ -309,12 +352,15 @@ static void wifi_event_handler(void *arg,
                     esp_wifi_connect();
                 }
             } else {
-                ESP_LOGE(TAG, "STA failed after %" PRIu32 " retries, falling back to AP",
-                         wifi_manager_max_retry());
+                ESP_LOGE(TAG,
+                         "STA failed after %" PRIu32 " retries, reason=%u, falling back to AP",
+                         wifi_manager_max_retry(),
+                         (unsigned)reason);
                 xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
                 fallback_to_ap();
             }
             return;
+        }
 
         case WIFI_EVENT_AP_START:
             s_ap_active = true;
@@ -392,12 +438,18 @@ static esp_err_t fallback_to_ap(void)
     s_sta_configured = false;
     s_retry_count = 0;
 
+    ESP_LOGW(TAG,
+             "Switching to AP fallback: ap_ssid=%s ap_auth=%s",
+             s_ap_ssid[0] ? s_ap_ssid : "-",
+             (s_config.ap_password && s_config.ap_password[0] != '\0') ? "wpa2_psk" : "open");
+
     esp_err_t err = esp_wifi_set_mode(WIFI_MODE_AP);
     if (err != ESP_OK) {
         return err;
     }
     apply_ap_config();
     refresh_ap_ip_str();
+    ESP_LOGW(TAG, "AP fallback active: ap_ssid=%s ap_ip=%s", s_ap_ssid, s_ap_ip);
     notify_state_changed(true);
     return ESP_OK;
 }
@@ -515,7 +567,13 @@ esp_err_t wifi_manager_wait_connected(uint32_t timeout_ms)
                                            pdFALSE,
                                            pdFALSE,
                                            ticks);
-    return (bits & WIFI_CONNECTED_BIT) ? ESP_OK : ESP_ERR_TIMEOUT;
+    if (bits & WIFI_CONNECTED_BIT) {
+        return ESP_OK;
+    }
+    if (bits & WIFI_FAIL_BIT) {
+        return ESP_FAIL;
+    }
+    return ESP_ERR_TIMEOUT;
 }
 
 esp_err_t wifi_manager_register_state_callback(wifi_manager_state_cb_t cb, void *user_ctx)


### PR DESCRIPTION
## Description
This PR fixes the main Wi-Fi issue for open STA networks and improves startup diagnostics.

## Changes
- Fix open-network STA connection by setting `sta_cfg.sta.threshold.authmode` to `WIFI_AUTH_OPEN` when `wifi_password` is empty.
- Keep WPA2 threshold for password-protected networks.
- Validate STA SSID/password length in app config validation and wifi manager validation to prevent silent truncation and invalid runtime apply.
- Improve startup connection result semantics by distinguishing retry-exhausted failure from timeout.
- Add sanitized startup/disconnect/fallback logs to improve field diagnostics.
- Update changelog entry for 2026-06-04 to reflect the open-network fix as the primary issue.

## Testing
- pre-commit run

## Related
- Related to #110