### PR TITLE
fix: keep stage and subagent text on UTF-8 character boundaries

### DIFF
--- a/components/claw_modules/claw_core/src/claw_core_events.c
+++ b/components/claw_modules/claw_core/src/claw_core_events.c
@@ -302,9 +302,11 @@ void claw_core_publish_stage_tool_calls(const claw_core_request_t *request,
         const char *name = response->tool_calls[i].name ? response->tool_calls[i].name : "?";
         const char *args = response->tool_calls[i].arguments_json;
         if (args && args[0]) {
-            written = snprintf(buf + off, sizeof(buf) - off, "%s%s(%.40s%s)",
-                               i == 0 ? "" : ", ", name, args,
-                               strlen(args) > 40 ? "..." : "");
+            size_t arg_len = strlen(args);
+            size_t prefix_len = utf8_prefix_len(args, 40);
+            written = snprintf(buf + off, sizeof(buf) - off, "%s%s(%.*s%s)",
+                               i == 0 ? "" : ", ", name, (int)prefix_len, args,
+                               arg_len > prefix_len ? "..." : "");
         } else {
             written = snprintf(buf + off, sizeof(buf) - off, "%s%s",
                                i == 0 ? "" : ", ", name);

--- a/components/claw_modules/claw_manager/src/claw_agent_mgr.c
+++ b/components/claw_modules/claw_manager/src/claw_agent_mgr.c
@@ -643,9 +643,13 @@ static void claw_agent_mgr_completion_observer(const claw_core_completion_summar
     if ((size_t)written >= sizeof(text)) {
         size_t suffix_len = strlen(truncated_suffix);
         if (suffix_len + 1U < sizeof(text)) {
-            strlcpy(text + sizeof(text) - suffix_len - 1U,
-                    truncated_suffix,
-                    suffix_len + 1U);
+            size_t p = sizeof(text) - suffix_len - 1U;
+            /* Back off so the suffix never splices into the middle of a
+             * multi-byte UTF-8 sequence, which would emit invalid bytes. */
+            while (p > 0 && ((unsigned char)text[p] & 0xC0) == 0x80) {
+                p--;
+            }
+            strlcpy(text + p, truncated_suffix, sizeof(text) - p);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two byte-level text truncations in the agent stage / notification path that can split a multi-byte UTF-8 character and emit an invalid byte sequence to downstream consumers. In non-English (CJK / emoji) deployments this surfaces as replacement characters (`�`) and, depending on the consumer's UTF-8 handling, can corrupt or break the message (e.g. a strict WebSocket text-frame validator rejecting the frame).

Both issues are present on current `master` (`4f9e2c0`).

## Changes

- **`claw_core`**: `claw_core_publish_stage_tool_calls()` truncated tool-call `arguments_json` with `"%.40s"`, cutting at a raw byte offset. The file already has a `utf8_prefix_len()` helper (used for the reasoning snippet just above), so the fix reuses it and the cut now lands on a character boundary.
- **`claw_manager`**: `claw_agent_mgr_completion_observer()` splices a `[truncated]` suffix into the `<subagent_completed>` buffer at a fixed byte offset on overflow, which can leave an orphaned partial UTF-8 character in the kept prefix. The splice offset is now backed off to a character boundary before the suffix is written.

## Implementation

- `claw_core`: compute `prefix_len = utf8_prefix_len(args, 40)` and print with `"%.*s"`; the ellipsis is shown when `strlen(args) > prefix_len`. This mirrors the existing reasoning-snippet path, so no new helper is introduced.
- `claw_manager`: before writing the suffix, decrement the splice offset while the byte at that position is a UTF-8 continuation byte (`(byte & 0xC0) == 0x80`), so the retained prefix always ends on a character boundary. The `strlcpy` size is widened to the real remaining buffer.
- No new public API; both changes are local to existing functions.

## Files

| File | Change |
| --- | --- |
| `components/claw_modules/claw_core/src/claw_core_events.c` | Reuse `utf8_prefix_len()` for tool-call args truncation instead of `"%.40s"` |
| `components/claw_modules/claw_manager/src/claw_agent_mgr.c` | Back the `[truncated]` splice offset off to a UTF-8 boundary |

## Test plan

- [x] Symptom reproduced end-to-end in a downstream integration: CJK tool args and long sub-agent `final_text` produced `�` / invalid UTF-8 in the stage and `<subagent_completed>` text; gone after the fix.
- [ ] Built in a clean ESP-IDF environment (pure logic change, no toolchain locally; relying on CI for the component build)
- [ ] Unit test added (none added; behavior verified manually)
