### PR TITLE
[codex] add SHTC3 environmental sensor support

### DIFF
--- a/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/README.md
+++ b/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/README.md
@@ -6,6 +6,18 @@
 - [ ] The RLCD screen is not colourful, so it's not fully compatible with ESP-Claw's animations. A good solution for converting colourful graphics to black-and-white should be found.  
 - [ ] [ST7305 Datasheet](https://www.waveshare.net/w/upload/5/5d/ST_7305_V0_2.pdf) Table 8.2.8 says it supports 4-levels greyscale, but Waveshare's official demo doesn't show this feature. Need to check if the screen support. If so, the display can be better.  
 
+## Onboard environmental sensor
+
+The board has a Sensirion SHTC3 temperature/humidity sensor on the shared
+`i2c_master` bus. SHTC3 uses the fixed 7-bit I2C address `0x70`; do not use
+the 8-bit write-address form `0xE0` in board or Lua configuration.
+
+The `environmental_sensor` Lua module logs SHTC3 probe, product ID CRC,
+measurement raw words, sample CRC bytes, and converted temperature/humidity.
+Display code should call `sensor:read_safe()` and use `temperature_display`
+and `humidity_display`; failed reads or CRC errors return `N/A` instead of a
+numeric placeholder.
+
 ## Related documentation
 - [Documentation for ESP32-S3-RLCD-4.2 (English)](https://docs.waveshare.com/ESP32-S3-RLCD-4.2)  
 - [Documentation for ESP32-S3-RLCD-4.2 (中文)](https://docs.waveshare.net/ESP32-S3-RLCD-4.2)  

--- a/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/board_devices.yaml
+++ b/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/board_devices.yaml
@@ -5,6 +5,9 @@ version: 1.0.0
 #   ES8311  – I2C 7-bit 0x18 (8-bit 0x30), DAC only (playback)
 #   ES7210  – I2C 7-bit 0x40 (8-bit 0x80), dual-mic ADC with reference channel
 #
+# Environmental sensor:
+#   SHTC3   – I2C fixed 7-bit 0x70
+#
 # Display:
 #   4.2-inch fully reflective monochrome LCD, 400 × 300 pixels
 #   Proprietary 1-bit-per-pixel SPI controller; initialization and frame
@@ -50,6 +53,22 @@ devices:
       - name: i2c_master
         address: 0x80           # 8-bit address (7-bit 0x40 << 1)
         frequency: 400000       # Hz
+
+  # ── Sensirion SHTC3 Temperature/Humidity Sensor ────────────────────────
+  # SHTC3 uses a fixed 7-bit I2C address 0x70. Do not configure 0xE0 here;
+  # that is the 8-bit write address representation and is rejected by the Lua
+  # I2C APIs.
+  - name: environmental_sensor
+    chip: shtc3
+    type: custom
+    version: 1.0.0
+    init_skip: true
+    config:
+      i2c_addr: 0x70
+      frequency: 400000
+      int_gpio_num: -1
+    peripherals:
+      - name: i2c_master
 
   # ── 4.2-inch Reflective Monochrome LCD ──────────────────────────────────
   # Fully custom 1-bpp SPI panel; all hardware init is in setup_device.c.

--- a/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/sdkconfig.defaults.board
+++ b/application/edge_agent/boards/waveshare/waveshare_ESP32_S3_RLCD_4_2/sdkconfig.defaults.board
@@ -21,6 +21,12 @@ CONFIG_SPIRAM_SPEED_80M=y
 # Enable display_lcd device support for the custom RLCD panel
 CONFIG_ESP_BOARD_DEV_DISPLAY_LCD_SUPPORT=y
 
+# Enable the onboard SHTC3 temperature/humidity sensor on I2C 7-bit address 0x70
+CONFIG_APP_CLAW_LUA_MODULE_ENVIRONMENTAL_SENSOR=y
+CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690=n
+CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_DHT=n
+CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3=y
+
 # Size-optimised build; move FreeRTOS and ring-buffer code out of IRAM to free
 # space for the LCD framebuffer, and reduce Wi-Fi IRAM usage similarly.
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/components/lua_modules/lua_module_environmental_sensor/CMakeLists.txt
+++ b/components/lua_modules/lua_module_environmental_sensor/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(env_sensor_srcs
     "src/lua_module_environmental_sensor.c"
+    "src/shtc3_math.c"
 )
 
 set(env_sensor_requires
@@ -13,6 +14,12 @@ set(env_sensor_priv_requires
 if(CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690)
     list(APPEND env_sensor_priv_requires
         espressif__bme690
+        espressif__i2c_bus
+    )
+endif()
+
+if(CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3)
+    list(APPEND env_sensor_priv_requires
         espressif__i2c_bus
     )
 endif()

--- a/components/lua_modules/lua_module_environmental_sensor/Kconfig
+++ b/components/lua_modules/lua_module_environmental_sensor/Kconfig
@@ -7,6 +7,13 @@ menu "Lua Environmental Sensor Module"
             Build the environmental sensor Lua module with the Bosch BME690
             backend.
 
+    config LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+        bool "Enable SHTC3 backend"
+        default n
+        help
+            Build the environmental sensor Lua module with the Sensirion SHTC3
+            temperature and humidity backend.
+
     config LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_DHT
         bool "Enable DHT backend"
         default y

--- a/components/lua_modules/lua_module_environmental_sensor/README.md
+++ b/components/lua_modules/lua_module_environmental_sensor/README.md
@@ -2,16 +2,18 @@
 
 This module describes how to read environmental data from Lua using one of
 multiple backends selected at build time and at runtime. It currently
-supports Bosch BME690 and DHT-family sensors.
+supports Bosch BME690, Sensirion SHTC3, and DHT-family sensors.
 
 ## How to call
 - Import it with `local environmental_sensor = require("environmental_sensor")`
 - Open the sensor with one of:
-  - `local sensor = environmental_sensor.new()` — default to the compiled BME690 backend
-  - `local sensor = environmental_sensor.new("environmental_sensor")` — choose a BME690 board device explicitly
+  - `local sensor = environmental_sensor.new()` — default to the first compiled I2C backend, or DHT when only DHT is enabled
+  - `local sensor = environmental_sensor.new("environmental_sensor")` — choose a board device explicitly
+  - `local sensor = environmental_sensor.new({ type = "shtc3", device = "environmental_sensor" })`
   - `local sensor = environmental_sensor.new({ type = "bme690", peripheral = "i2c_master" })`
   - `local sensor = environmental_sensor.new({ type = "dht", pin = 4, sensor_type = "dht22" })`
 - Read all values with `local sample = sensor:read()`
+- Read display-safe values with `local sample = sensor:read_safe()`
 - Or read one value at a time:
   - `sensor:read_temperature()`
   - `sensor:read_humidity()`
@@ -20,6 +22,8 @@ supports Bosch BME690 and DHT-family sensors.
   - `sensor:read_gas()`
 - Inspect sensor identity with:
   - `sensor:name()`
+- SHTC3-only identity helpers:
+  - `sensor:product_id()`
 - BME690-only identity helpers:
   - `sensor:chip_id()`
   - `sensor:variant_id()`
@@ -30,10 +34,10 @@ All fields are optional unless the chosen backend requires them.
 
 | Field              | Type    | Meaning                                                         |
 |--------------------|---------|-----------------------------------------------------------------|
-| `type`             | string  | Backend type: `"bme690"` or `"dht"`                             |
+| `type`             | string  | Backend type: `"shtc3"`, `"bme690"` or `"dht"`                  |
 | `device`           | string  | Board device name to load defaults from                         |
 | `peripheral`       | string  | Board I2C master peripheral name, e.g. `"i2c_master"`          |
-| `i2c_addr`         | integer | BME690 7-bit I2C address, `0x76` or `0x77`                     |
+| `i2c_addr`         | integer | I2C 7-bit address. SHTC3 is fixed at `0x70`; BME690 uses `0x76` or `0x77` |
 | `frequency`        | integer | I2C clock in Hz (default `400000`)                             |
 | `heater_temp`      | integer | Heater target temperature in Celsius (default `300`)           |
 | `heater_duration`  | integer | Heater duration in milliseconds (default `100`)                |
@@ -44,12 +48,40 @@ All fields are optional unless the chosen backend requires them.
 - Common:
   - `sample.temperature` — degrees Celsius
   - `sample.humidity` — relative humidity in percent
+  - `sample.temperature_display` — formatted value from `read_safe()`, or `"N/A"`
+  - `sample.humidity_display` — formatted value from `read_safe()`, or `"N/A"`
+  - `sample.ok` — boolean success flag from `read_safe()`
+  - `sample.error` — error string from `read_safe()` failures
+- SHTC3-only:
+  - `sample.raw_temperature` — raw 16-bit SHTC3 temperature word
+  - `sample.raw_humidity` — raw 16-bit SHTC3 humidity word
+  - `sample.temperature_crc` — CRC byte returned with the temperature word
+  - `sample.humidity_crc` — CRC byte returned with the humidity word
 - BME690-only:
   - `sample.pressure` — pressure in Pa
   - `sample.gas_resistance` — gas resistance in ohms
   - `sample.status` — raw BME690 status flags
   - `sample.gas_index` — gas measurement index from the driver
   - `sample.meas_index` — measurement index from the driver
+
+## Example: SHTC3
+```lua
+local environmental_sensor = require("environmental_sensor")
+
+local sensor = environmental_sensor.new({
+    type = "shtc3",
+    device = "environmental_sensor",
+})
+
+local sample = sensor:read_safe()
+print(string.format("temperature: %s C", sample.temperature_display))
+print(string.format("humidity: %s %%", sample.humidity_display))
+if not sample.ok then
+    print("read failed: " .. tostring(sample.error))
+end
+
+sensor:close()
+```
 
 ## Example: BME690
 ```lua
@@ -87,6 +119,12 @@ sensor:close()
 ## Notes
 - Reads are blocking.
 - Each BME690 call triggers a forced-mode measurement.
-- The BME690 board device must resolve to a valid I2C peripheral, or you must
+- SHTC3 logs the selected 7-bit I2C address, product-id CRC result, raw sample
+  words, sample CRC bytes, and converted temperature/humidity.
+- `read()` keeps the legacy behavior and raises a Lua error on failure.
+- `read_safe()` is intended for display paths: when a sample cannot be read or
+  its CRC is invalid, it returns `temperature_display = "N/A"` and
+  `humidity_display = "N/A"` instead of numeric placeholder values.
+- The I2C board device must resolve to a valid I2C peripheral, or you must
   pass `peripheral` explicitly in Lua.
-- Any setup or read failure raises a Lua error.
+- Setup failures still raise a Lua error because no sensor handle exists.

--- a/components/lua_modules/lua_module_environmental_sensor/idf_component.yml
+++ b/components/lua_modules/lua_module_environmental_sensor/idf_component.yml
@@ -2,4 +2,5 @@
 dependencies:
   espressif/bme690:
     version: "*"
+  espressif/i2c_bus: ^1.5.1
   esp-idf-lib/dht: ^1.2.0

--- a/components/lua_modules/lua_module_environmental_sensor/src/lua_module_environmental_sensor.c
+++ b/components/lua_modules/lua_module_environmental_sensor/src/lua_module_environmental_sensor.c
@@ -8,6 +8,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -15,6 +16,8 @@
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690
 #include "bme69x.h"
 #include "bme69x_defs.h"
+#endif
+#if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690 || CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
 #include "esp_board_device.h"
 #include "esp_board_manager.h"
 #include "esp_board_periph.h"
@@ -27,6 +30,9 @@
 #include "dht.h"
 #include "driver/gpio.h"
 #endif
+#if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+#include "shtc3_math.h"
+#endif
 #include "esp_rom_sys.h"
 #include "esp_log.h"
 #include "lauxlib.h"
@@ -34,6 +40,37 @@
 #define LUA_MODULE_ENVIRONMENTAL_SENSOR_NAME      "environmental_sensor"
 #define LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_DHT  "dht"
 #define LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_BME690 "bme690"
+#define LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_SHTC3 "shtc3"
+#define LUA_MODULE_ENVIRONMENTAL_SENSOR_DISPLAY_NA "N/A"
+
+static void lua_module_environmental_sensor_set_display_number(lua_State *L,
+                                                               const char *field,
+                                                               float value)
+{
+    char buf[24];
+    snprintf(buf, sizeof(buf), "%.2f", (double)value);
+    lua_pushstring(L, buf);
+    lua_setfield(L, -2, field);
+}
+
+static void lua_module_environmental_sensor_set_na_display(lua_State *L)
+{
+    lua_pushstring(L, LUA_MODULE_ENVIRONMENTAL_SENSOR_DISPLAY_NA);
+    lua_setfield(L, -2, "temperature_display");
+    lua_pushstring(L, LUA_MODULE_ENVIRONMENTAL_SENSOR_DISPLAY_NA);
+    lua_setfield(L, -2, "humidity_display");
+}
+
+static void lua_module_environmental_sensor_push_safe_error(lua_State *L,
+                                                            const char *error)
+{
+    lua_newtable(L);
+    lua_pushboolean(L, false);
+    lua_setfield(L, -2, "ok");
+    lua_module_environmental_sensor_set_na_display(L);
+    lua_pushstring(L, error);
+    lua_setfield(L, -2, "error");
+}
 
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690
 #define LUA_MODULE_BME690_METATABLE        "environmental_sensor.device"
@@ -465,6 +502,39 @@ static int lua_module_bme690_read(lua_State *L)
     return 1;
 }
 
+static int lua_module_bme690_read_safe(lua_State *L)
+{
+    lua_module_bme690_ud_t *ud = lua_module_bme690_get_ud(L, 1);
+    struct bme69x_data data = { 0 };
+
+    esp_err_t err = lua_module_bme690_read_sample(ud->handle, &data);
+    if (err != ESP_OK) {
+        lua_module_environmental_sensor_push_safe_error(L, esp_err_to_name(err));
+        return 1;
+    }
+
+    lua_newtable(L);
+    lua_pushboolean(L, true);
+    lua_setfield(L, -2, "ok");
+    lua_pushnumber(L, data.temperature);
+    lua_setfield(L, -2, "temperature");
+    lua_pushnumber(L, data.pressure);
+    lua_setfield(L, -2, "pressure");
+    lua_pushnumber(L, data.humidity);
+    lua_setfield(L, -2, "humidity");
+    lua_pushnumber(L, data.gas_resistance);
+    lua_setfield(L, -2, "gas_resistance");
+    lua_pushinteger(L, data.status);
+    lua_setfield(L, -2, "status");
+    lua_pushinteger(L, data.gas_index);
+    lua_setfield(L, -2, "gas_index");
+    lua_pushinteger(L, data.meas_index);
+    lua_setfield(L, -2, "meas_index");
+    lua_module_environmental_sensor_set_display_number(L, "temperature_display", data.temperature);
+    lua_module_environmental_sensor_set_display_number(L, "humidity_display", data.humidity);
+    return 1;
+}
+
 static int lua_module_bme690_read_temperature(lua_State *L)
 {
     lua_module_bme690_ud_t *ud = lua_module_bme690_get_ud(L, 1);
@@ -710,6 +780,640 @@ static int lua_module_bme690_new(lua_State *L)
 }
 #endif
 
+#if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+#define LUA_MODULE_SHTC3_METATABLE        "environmental_sensor.shtc3_device"
+#define LUA_MODULE_SHTC3_DEFAULT_NAME     "environmental_sensor"
+#define LUA_MODULE_SHTC3_MAX_NAME_LEN     64
+#define LUA_MODULE_SHTC3_DEFAULT_FREQ_HZ  400000
+#define LUA_MODULE_SHTC3_I2C_ADDR         0x70
+#define LUA_MODULE_SHTC3_CMD_WAKEUP       0x3517
+#define LUA_MODULE_SHTC3_CMD_SLEEP        0xb098
+#define LUA_MODULE_SHTC3_CMD_READ_ID      0xefc8
+#define LUA_MODULE_SHTC3_CMD_MEASURE      0x7866
+#define LUA_MODULE_SHTC3_WAKE_DELAY_US    300
+#define LUA_MODULE_SHTC3_MEASURE_DELAY_MS 15
+
+static const char *SHTC3_TAG = "lua_module_shtc3";
+
+typedef struct {
+    float temperature;
+    float humidity;
+    uint16_t raw_temperature;
+    uint16_t raw_humidity;
+    uint8_t temperature_crc;
+    uint8_t humidity_crc;
+} lua_module_shtc3_sample_t;
+
+typedef struct {
+    i2c_bus_handle_t i2c_bus_handle;
+    i2c_bus_device_handle_t i2c_dev_handle;
+    char peripheral_name[LUA_MODULE_SHTC3_MAX_NAME_LEN];
+    bool peripheral_ref_held;
+    bool sensor_initialized;
+    uint8_t i2c_addr;
+    uint16_t product_id;
+} lua_module_shtc3_handle_t;
+
+typedef struct {
+    lua_module_shtc3_handle_t *handle;
+    char device_name[LUA_MODULE_SHTC3_MAX_NAME_LEN];
+} lua_module_shtc3_ud_t;
+
+typedef struct {
+    const char *name;
+    const char *type;
+    const char *chip;
+    int8_t i2c_addr;
+    int32_t frequency;
+    int8_t int_gpio_num;
+    uint8_t peripheral_count;
+    const char *peripheral_name;
+} lua_shtc3_board_cfg_t;
+
+typedef struct {
+    char peripheral_name[LUA_MODULE_SHTC3_MAX_NAME_LEN];
+    int i2c_addr;
+    int frequency;
+    bool has_peripheral;
+    bool has_i2c_addr;
+    bool has_frequency;
+} lua_shtc3_resolved_cfg_t;
+
+static void lua_module_shtc3_destroy_handle(lua_module_shtc3_handle_t *handle);
+
+static esp_err_t lua_module_shtc3_open_i2c_bus(const char *peripheral_name,
+                                               int frequency,
+                                               i2c_bus_handle_t *i2c_bus_handle,
+                                               bool *peripheral_ref_held)
+{
+    i2c_master_bus_handle_t i2c_master_handle = NULL;
+    i2c_master_bus_config_t *i2c_master_cfg = NULL;
+
+    *peripheral_ref_held = false;
+
+    ESP_RETURN_ON_ERROR(esp_board_periph_ref_handle(peripheral_name, (void **)&i2c_master_handle),
+                        SHTC3_TAG, "Failed to reference board I2C bus '%s'", peripheral_name);
+    *peripheral_ref_held = true;
+
+    esp_err_t err = esp_board_periph_get_config(peripheral_name, (void **)&i2c_master_cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(SHTC3_TAG, "Failed to get board I2C config '%s': %s",
+                 peripheral_name, esp_err_to_name(err));
+        esp_board_periph_unref_handle(peripheral_name);
+        *peripheral_ref_held = false;
+        return err;
+    }
+
+    const i2c_config_t i2c_bus_cfg = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = i2c_master_cfg->sda_io_num,
+        .scl_io_num = i2c_master_cfg->scl_io_num,
+        .sda_pullup_en = i2c_master_cfg->flags.enable_internal_pullup,
+        .scl_pullup_en = i2c_master_cfg->flags.enable_internal_pullup,
+        .master.clk_speed = (uint32_t)frequency,
+        .clk_flags = 0,
+    };
+
+    (void)i2c_master_handle;
+    *i2c_bus_handle = i2c_bus_create(i2c_master_cfg->i2c_port, &i2c_bus_cfg);
+    if (*i2c_bus_handle == NULL) {
+        esp_board_periph_unref_handle(peripheral_name);
+        *peripheral_ref_held = false;
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t lua_module_shtc3_select_addr(lua_module_shtc3_handle_t *handle, uint8_t i2c_addr)
+{
+    if (handle->i2c_dev_handle != NULL && handle->i2c_addr == i2c_addr) {
+        return ESP_OK;
+    }
+
+    if (i2c_addr != LUA_MODULE_SHTC3_I2C_ADDR) {
+        ESP_LOGE(SHTC3_TAG, "Unsupported SHTC3 I2C address 0x%02x, expected 7-bit 0x%02x",
+                 i2c_addr, LUA_MODULE_SHTC3_I2C_ADDR);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (handle->i2c_dev_handle != NULL) {
+        i2c_bus_device_delete(&handle->i2c_dev_handle);
+        handle->i2c_dev_handle = NULL;
+    }
+
+    handle->i2c_dev_handle = i2c_bus_device_create(handle->i2c_bus_handle, i2c_addr, 0);
+    if (handle->i2c_dev_handle == NULL) {
+        ESP_LOGE(SHTC3_TAG, "Failed to create SHTC3 I2C device for 7-bit address 0x%02x", i2c_addr);
+        return ESP_FAIL;
+    }
+
+    handle->i2c_addr = i2c_addr;
+    return ESP_OK;
+}
+
+static esp_err_t lua_module_shtc3_write_command(lua_module_shtc3_handle_t *handle,
+                                                uint16_t command,
+                                                const char *label)
+{
+    uint8_t buf[2] = {
+        (uint8_t)(command >> 8),
+        (uint8_t)(command & 0xff),
+    };
+    esp_err_t err = i2c_bus_write_bytes(handle->i2c_dev_handle, NULL_I2C_MEM_ADDR,
+                                        sizeof(buf), buf);
+    if (err != ESP_OK) {
+        ESP_LOGE(SHTC3_TAG, "SHTC3 %s command 0x%04x failed at addr=0x%02x: %s",
+                 label, command, handle->i2c_addr, esp_err_to_name(err));
+    }
+    return err;
+}
+
+static esp_err_t lua_module_shtc3_wakeup(lua_module_shtc3_handle_t *handle)
+{
+    esp_err_t err = lua_module_shtc3_write_command(handle, LUA_MODULE_SHTC3_CMD_WAKEUP, "wakeup");
+    if (err == ESP_OK) {
+        esp_rom_delay_us(LUA_MODULE_SHTC3_WAKE_DELAY_US);
+    }
+    return err;
+}
+
+static esp_err_t lua_module_shtc3_sleep(lua_module_shtc3_handle_t *handle)
+{
+    return lua_module_shtc3_write_command(handle, LUA_MODULE_SHTC3_CMD_SLEEP, "sleep");
+}
+
+static esp_err_t lua_module_shtc3_read_product_id(lua_module_shtc3_handle_t *handle,
+                                                  uint16_t *product_id)
+{
+    uint8_t id_buf[3] = { 0 };
+    esp_err_t err = lua_module_shtc3_wakeup(handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = lua_module_shtc3_write_command(handle, LUA_MODULE_SHTC3_CMD_READ_ID, "read-id");
+    if (err == ESP_OK) {
+        err = i2c_bus_read_bytes(handle->i2c_dev_handle, NULL_I2C_MEM_ADDR,
+                                 sizeof(id_buf), id_buf);
+    }
+
+    esp_err_t sleep_err = lua_module_shtc3_sleep(handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(SHTC3_TAG, "SHTC3 read-id failed at addr=0x%02x: %s",
+                 handle->i2c_addr, esp_err_to_name(err));
+        return err;
+    }
+    if (sleep_err != ESP_OK) {
+        return sleep_err;
+    }
+
+    uint8_t expected_crc = shtc3_crc8(id_buf, 2);
+    if (expected_crc != id_buf[2]) {
+        ESP_LOGE(SHTC3_TAG, "SHTC3 read-id CRC mismatch addr=0x%02x id=0x%02x%02x crc=0x%02x expected=0x%02x",
+                 handle->i2c_addr, id_buf[0], id_buf[1], id_buf[2], expected_crc);
+        return ESP_ERR_INVALID_CRC;
+    }
+
+    *product_id = ((uint16_t)id_buf[0] << 8) | id_buf[1];
+    ESP_LOGI(SHTC3_TAG, "SHTC3 probe ok addr=0x%02x product_id=0x%04x crc=0x%02x",
+             handle->i2c_addr, *product_id, id_buf[2]);
+    return ESP_OK;
+}
+
+static esp_err_t lua_module_shtc3_read_sample(lua_module_shtc3_handle_t *handle,
+                                              lua_module_shtc3_sample_t *sample)
+{
+    uint8_t data[6] = { 0 };
+
+    esp_err_t err = lua_module_shtc3_wakeup(handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = lua_module_shtc3_write_command(handle, LUA_MODULE_SHTC3_CMD_MEASURE, "measure");
+    if (err == ESP_OK) {
+        vTaskDelay(pdMS_TO_TICKS(LUA_MODULE_SHTC3_MEASURE_DELAY_MS));
+        err = i2c_bus_read_bytes(handle->i2c_dev_handle, NULL_I2C_MEM_ADDR,
+                                 sizeof(data), data);
+    }
+
+    esp_err_t sleep_err = lua_module_shtc3_sleep(handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(SHTC3_TAG, "SHTC3 measurement read failed addr=0x%02x: %s",
+                 handle->i2c_addr, esp_err_to_name(err));
+        return err;
+    }
+    if (sleep_err != ESP_OK) {
+        return sleep_err;
+    }
+
+    uint8_t temperature_crc = shtc3_crc8(&data[0], 2);
+    uint8_t humidity_crc = shtc3_crc8(&data[3], 2);
+    if (temperature_crc != data[2] || humidity_crc != data[5]) {
+        ESP_LOGE(SHTC3_TAG,
+                 "SHTC3 sample CRC mismatch addr=0x%02x "
+                 "temp_raw=0x%02x%02x temp_crc=0x%02x expected=0x%02x "
+                 "hum_raw=0x%02x%02x hum_crc=0x%02x expected=0x%02x",
+                 handle->i2c_addr,
+                 data[0], data[1], data[2], temperature_crc,
+                 data[3], data[4], data[5], humidity_crc);
+        return ESP_ERR_INVALID_CRC;
+    }
+
+    sample->raw_temperature = ((uint16_t)data[0] << 8) | data[1];
+    sample->raw_humidity = ((uint16_t)data[3] << 8) | data[4];
+    sample->temperature_crc = data[2];
+    sample->humidity_crc = data[5];
+    sample->temperature = shtc3_raw_to_celsius(sample->raw_temperature);
+    sample->humidity = shtc3_raw_to_humidity(sample->raw_humidity);
+
+    ESP_LOGI(SHTC3_TAG,
+             "SHTC3 sample ok addr=0x%02x raw_temperature=0x%04x raw_humidity=0x%04x "
+             "temperature=%.2fC humidity=%.2f%% temp_crc=0x%02x humidity_crc=0x%02x",
+             handle->i2c_addr, sample->raw_temperature, sample->raw_humidity,
+             (double)sample->temperature, (double)sample->humidity,
+             sample->temperature_crc, sample->humidity_crc);
+    return ESP_OK;
+}
+
+static esp_err_t lua_module_shtc3_create_handle(const lua_shtc3_resolved_cfg_t *cfg,
+                                                lua_module_shtc3_handle_t **out_handle)
+{
+    lua_module_shtc3_handle_t *handle = calloc(1, sizeof(lua_module_shtc3_handle_t));
+    if (handle == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    snprintf(handle->peripheral_name, sizeof(handle->peripheral_name), "%s", cfg->peripheral_name);
+
+    ESP_LOGI(SHTC3_TAG, "Opening SHTC3 on %s, 7-bit addr 0x%02x, freq %d Hz",
+             cfg->peripheral_name, cfg->i2c_addr, cfg->frequency);
+
+    esp_err_t err = lua_module_shtc3_open_i2c_bus(cfg->peripheral_name, cfg->frequency,
+                                                  &handle->i2c_bus_handle,
+                                                  &handle->peripheral_ref_held);
+    if (err != ESP_OK) {
+        free(handle);
+        return err;
+    }
+
+    err = lua_module_shtc3_select_addr(handle, (uint8_t)cfg->i2c_addr);
+    if (err != ESP_OK) {
+        lua_module_shtc3_destroy_handle(handle);
+        return err;
+    }
+
+    err = lua_module_shtc3_read_product_id(handle, &handle->product_id);
+    if (err != ESP_OK) {
+        lua_module_shtc3_destroy_handle(handle);
+        return err == ESP_ERR_INVALID_CRC ? err : ESP_ERR_NOT_FOUND;
+    }
+
+    handle->sensor_initialized = true;
+    *out_handle = handle;
+    return ESP_OK;
+}
+
+static void lua_module_shtc3_destroy_handle(lua_module_shtc3_handle_t *handle)
+{
+    if (handle == NULL) {
+        return;
+    }
+
+    if (handle->i2c_dev_handle != NULL) {
+        i2c_bus_device_delete(&handle->i2c_dev_handle);
+        handle->i2c_dev_handle = NULL;
+    }
+    if (handle->i2c_bus_handle != NULL) {
+        if (handle->peripheral_ref_held) {
+            handle->i2c_bus_handle = NULL;
+        } else {
+            i2c_bus_delete(&handle->i2c_bus_handle);
+        }
+    }
+    if (handle->peripheral_ref_held && handle->peripheral_name[0] != '\0') {
+        esp_board_periph_unref_handle(handle->peripheral_name);
+    }
+    free(handle);
+}
+
+static lua_module_shtc3_ud_t *lua_module_shtc3_get_ud(lua_State *L, int idx)
+{
+    lua_module_shtc3_ud_t *ud =
+        (lua_module_shtc3_ud_t *)luaL_checkudata(L, idx, LUA_MODULE_SHTC3_METATABLE);
+    if (!ud || !ud->handle || !ud->handle->sensor_initialized) {
+        luaL_error(L, "environmental_sensor: invalid or closed shtc3 handle");
+    }
+    return ud;
+}
+
+static int lua_module_shtc3_close_impl(lua_State *L, lua_module_shtc3_ud_t *ud)
+{
+    (void)L;
+    if (ud->handle != NULL) {
+        lua_module_shtc3_destroy_handle(ud->handle);
+        ud->handle = NULL;
+    }
+    ud->device_name[0] = '\0';
+    return 0;
+}
+
+static int lua_module_shtc3_gc(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud =
+        (lua_module_shtc3_ud_t *)luaL_testudata(L, 1, LUA_MODULE_SHTC3_METATABLE);
+    if (ud && ud->handle) {
+        return lua_module_shtc3_close_impl(L, ud);
+    }
+    return 0;
+}
+
+static int lua_module_shtc3_close(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud =
+        (lua_module_shtc3_ud_t *)luaL_checkudata(L, 1, LUA_MODULE_SHTC3_METATABLE);
+    if (ud->handle) {
+        return lua_module_shtc3_close_impl(L, ud);
+    }
+    return 0;
+}
+
+static int lua_module_shtc3_name(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_pushstring(L, ud->device_name);
+    return 1;
+}
+
+static int lua_module_shtc3_product_id(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_pushinteger(L, ud->handle->product_id);
+    return 1;
+}
+
+static void lua_module_shtc3_push_sample(lua_State *L, const lua_module_shtc3_sample_t *sample)
+{
+    lua_newtable(L);
+    lua_pushnumber(L, sample->temperature);
+    lua_setfield(L, -2, "temperature");
+    lua_pushnumber(L, sample->humidity);
+    lua_setfield(L, -2, "humidity");
+    lua_pushinteger(L, sample->raw_temperature);
+    lua_setfield(L, -2, "raw_temperature");
+    lua_pushinteger(L, sample->raw_humidity);
+    lua_setfield(L, -2, "raw_humidity");
+    lua_pushinteger(L, sample->temperature_crc);
+    lua_setfield(L, -2, "temperature_crc");
+    lua_pushinteger(L, sample->humidity_crc);
+    lua_setfield(L, -2, "humidity_crc");
+}
+
+static int lua_module_shtc3_read(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_module_shtc3_sample_t sample = { 0 };
+
+    esp_err_t err = lua_module_shtc3_read_sample(ud->handle, &sample);
+    if (err != ESP_OK) {
+        return luaL_error(L, "environmental_sensor shtc3 read failed: %s", esp_err_to_name(err));
+    }
+
+    lua_module_shtc3_push_sample(L, &sample);
+    return 1;
+}
+
+static int lua_module_shtc3_read_safe(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_module_shtc3_sample_t sample = { 0 };
+
+    esp_err_t err = lua_module_shtc3_read_sample(ud->handle, &sample);
+    if (err != ESP_OK) {
+        lua_module_environmental_sensor_push_safe_error(L, esp_err_to_name(err));
+        return 1;
+    }
+
+    lua_module_shtc3_push_sample(L, &sample);
+    lua_pushboolean(L, true);
+    lua_setfield(L, -2, "ok");
+    lua_module_environmental_sensor_set_display_number(L, "temperature_display", sample.temperature);
+    lua_module_environmental_sensor_set_display_number(L, "humidity_display", sample.humidity);
+    return 1;
+}
+
+static int lua_module_shtc3_read_temperature(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_module_shtc3_sample_t sample = { 0 };
+
+    esp_err_t err = lua_module_shtc3_read_sample(ud->handle, &sample);
+    if (err != ESP_OK) {
+        return luaL_error(L, "environmental_sensor shtc3 read_temperature failed: %s", esp_err_to_name(err));
+    }
+
+    lua_pushnumber(L, sample.temperature);
+    return 1;
+}
+
+static int lua_module_shtc3_read_humidity(lua_State *L)
+{
+    lua_module_shtc3_ud_t *ud = lua_module_shtc3_get_ud(L, 1);
+    lua_module_shtc3_sample_t sample = { 0 };
+
+    esp_err_t err = lua_module_shtc3_read_sample(ud->handle, &sample);
+    if (err != ESP_OK) {
+        return luaL_error(L, "environmental_sensor shtc3 read_humidity failed: %s", esp_err_to_name(err));
+    }
+
+    lua_pushnumber(L, sample.humidity);
+    return 1;
+}
+
+static esp_err_t lua_shtc3_resolve_board_cfg(const char *device_name,
+                                             const lua_shtc3_board_cfg_t **out)
+{
+    extern const esp_board_device_desc_t g_esp_board_devices[];
+    const esp_board_device_desc_t *desc = g_esp_board_devices;
+    while (desc != NULL && desc->name != NULL) {
+        if (strcmp(desc->name, device_name) == 0) {
+            if (desc->cfg == NULL) {
+                return ESP_ERR_NOT_FOUND;
+            }
+            if (desc->cfg_size != sizeof(lua_shtc3_board_cfg_t)) {
+                ESP_LOGE(SHTC3_TAG,
+                         "Board device '%s' cfg_size=%u differs from expected %u; "
+                         "board_devices.yaml schema is out of sync with lua_shtc3_board_cfg_t.",
+                         device_name,
+                         (unsigned)desc->cfg_size,
+                         (unsigned)sizeof(lua_shtc3_board_cfg_t));
+                return ESP_ERR_INVALID_SIZE;
+            }
+            *out = (const lua_shtc3_board_cfg_t *)desc->cfg;
+            return ESP_OK;
+        }
+        desc = desc->next;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+static esp_err_t lua_module_shtc3_load_board_defaults(const char *device_name,
+                                                      lua_shtc3_resolved_cfg_t *out)
+{
+    const lua_shtc3_board_cfg_t *board = NULL;
+    esp_err_t err = lua_shtc3_resolve_board_cfg(device_name, &board);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (board->chip != NULL && strcmp(board->chip, LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_SHTC3) != 0) {
+        ESP_LOGW(SHTC3_TAG, "Board device '%s' chip='%s' does not match SHTC3 backend",
+                 device_name, board->chip);
+    }
+
+    if (board->peripheral_name != NULL && board->peripheral_name[0] != '\0') {
+        snprintf(out->peripheral_name, sizeof(out->peripheral_name), "%s", board->peripheral_name);
+        out->has_peripheral = true;
+    }
+    if (board->i2c_addr != 0) {
+        out->i2c_addr = board->i2c_addr;
+        out->has_i2c_addr = true;
+    }
+    if (board->frequency > 0) {
+        out->frequency = board->frequency;
+        out->has_frequency = true;
+    }
+
+    return ESP_OK;
+}
+
+static void lua_module_shtc3_apply_lua_overrides(lua_State *L, int opts_idx,
+                                                 lua_shtc3_resolved_cfg_t *cfg)
+{
+    if (opts_idx == 0 || lua_type(L, opts_idx) != LUA_TTABLE) {
+        return;
+    }
+
+    lua_getfield(L, opts_idx, "peripheral");
+    if (lua_isstring(L, -1)) {
+        const char *p = lua_tostring(L, -1);
+        snprintf(cfg->peripheral_name, sizeof(cfg->peripheral_name), "%s", p);
+        cfg->has_peripheral = true;
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, opts_idx, "i2c_addr");
+    if (lua_isnumber(L, -1)) {
+        cfg->i2c_addr = (int)lua_tointeger(L, -1);
+        cfg->has_i2c_addr = true;
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, opts_idx, "frequency");
+    if (lua_isnumber(L, -1)) {
+        cfg->frequency = (int)lua_tointeger(L, -1);
+        cfg->has_frequency = true;
+    }
+    lua_pop(L, 1);
+}
+
+static int lua_module_shtc3_new(lua_State *L)
+{
+    const char *device_name = LUA_MODULE_SHTC3_DEFAULT_NAME;
+    int opts_idx = 0;
+
+    if (lua_isstring(L, 1)) {
+        device_name = lua_tostring(L, 1);
+        if (lua_istable(L, 2)) {
+            opts_idx = 2;
+        }
+    } else if (lua_istable(L, 1)) {
+        opts_idx = 1;
+        lua_getfield(L, 1, "device");
+        if (lua_isstring(L, -1)) {
+            device_name = lua_tostring(L, -1);
+        }
+        lua_pop(L, 1);
+    }
+
+    if (strlen(device_name) >= LUA_MODULE_SHTC3_MAX_NAME_LEN) {
+        return luaL_error(L, "environmental_sensor device name too long");
+    }
+
+    lua_shtc3_resolved_cfg_t cfg = { 0 };
+    esp_err_t err = lua_module_shtc3_load_board_defaults(device_name, &cfg);
+    if (err == ESP_ERR_INVALID_SIZE) {
+        return luaL_error(L,
+                          "environmental_sensor.new: board device '%s' config schema mismatch "
+                          "(see error log above for details)", device_name);
+    }
+
+    lua_module_shtc3_apply_lua_overrides(L, opts_idx, &cfg);
+
+    if (!cfg.has_peripheral) {
+        return luaL_error(L, "environmental_sensor.new: missing 'peripheral' (board declares no '%s', "
+                              "and no override given)", device_name);
+    }
+    if (!cfg.has_i2c_addr) {
+        cfg.i2c_addr = LUA_MODULE_SHTC3_I2C_ADDR;
+        cfg.has_i2c_addr = true;
+    }
+    if (!cfg.has_frequency) {
+        cfg.frequency = LUA_MODULE_SHTC3_DEFAULT_FREQ_HZ;
+        cfg.has_frequency = true;
+    }
+    if (cfg.i2c_addr != LUA_MODULE_SHTC3_I2C_ADDR) {
+        return luaL_error(L,
+                          "environmental_sensor.new: unsupported SHTC3 I2C address 0x%02x "
+                          "(expected 7-bit 0x70, not 8-bit 0xe0)",
+                          cfg.i2c_addr);
+    }
+
+    lua_module_shtc3_handle_t *handle = NULL;
+    err = lua_module_shtc3_create_handle(&cfg, &handle);
+    if (err != ESP_OK || handle == NULL) {
+        return luaL_error(L, "environmental_sensor.new failed: %s",
+                          esp_err_to_name(err != ESP_OK ? err : ESP_FAIL));
+    }
+
+    lua_module_shtc3_ud_t *ud =
+        (lua_module_shtc3_ud_t *)lua_newuserdata(L, sizeof(*ud));
+    memset(ud, 0, sizeof(*ud));
+    ud->handle = handle;
+    snprintf(ud->device_name, sizeof(ud->device_name), "%s", device_name);
+
+    luaL_getmetatable(L, LUA_MODULE_SHTC3_METATABLE);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+static void lua_module_shtc3_create_metatable(lua_State *L)
+{
+    if (luaL_newmetatable(L, LUA_MODULE_SHTC3_METATABLE)) {
+        lua_pushcfunction(L, lua_module_shtc3_gc);
+        lua_setfield(L, -2, "__gc");
+        lua_pushvalue(L, -1);
+        lua_setfield(L, -2, "__index");
+        lua_pushcfunction(L, lua_module_shtc3_read);
+        lua_setfield(L, -2, "read");
+        lua_pushcfunction(L, lua_module_shtc3_read_safe);
+        lua_setfield(L, -2, "read_safe");
+        lua_pushcfunction(L, lua_module_shtc3_read_temperature);
+        lua_setfield(L, -2, "read_temperature");
+        lua_pushcfunction(L, lua_module_shtc3_read_humidity);
+        lua_setfield(L, -2, "read_humidity");
+        lua_pushcfunction(L, lua_module_shtc3_product_id);
+        lua_setfield(L, -2, "product_id");
+        lua_pushcfunction(L, lua_module_shtc3_name);
+        lua_setfield(L, -2, "name");
+        lua_pushcfunction(L, lua_module_shtc3_close);
+        lua_setfield(L, -2, "close");
+    }
+    lua_pop(L, 1);
+}
+#endif
+
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_DHT
 #define LUA_MODULE_DHT_METATABLE           "environmental_sensor.dht_device"
 #define LUA_MODULE_DHT_DEFAULT_TYPE        DHT_TYPE_DHT11
@@ -797,6 +1501,30 @@ static int lua_module_dht_read(lua_State *L)
     lua_setfield(L, -2, "temperature");
     lua_pushnumber(L, humidity);
     lua_setfield(L, -2, "humidity");
+    return 1;
+}
+
+static int lua_module_dht_read_safe(lua_State *L)
+{
+    lua_module_dht_ud_t *ud = lua_module_dht_get_ud(L, 1);
+    float humidity = 0;
+    float temperature = 0;
+
+    esp_err_t err = lua_module_dht_read_float(ud->sensor_type, ud->pin, &temperature, &humidity);
+    if (err != ESP_OK) {
+        lua_module_environmental_sensor_push_safe_error(L, esp_err_to_name(err));
+        return 1;
+    }
+
+    lua_newtable(L);
+    lua_pushboolean(L, true);
+    lua_setfield(L, -2, "ok");
+    lua_pushnumber(L, temperature);
+    lua_setfield(L, -2, "temperature");
+    lua_pushnumber(L, humidity);
+    lua_setfield(L, -2, "humidity");
+    lua_module_environmental_sensor_set_display_number(L, "temperature_display", temperature);
+    lua_module_environmental_sensor_set_display_number(L, "humidity_display", humidity);
     return 1;
 }
 
@@ -893,6 +1621,8 @@ static void lua_module_dht_create_metatable(lua_State *L)
         lua_setfield(L, -2, "__index");
         lua_pushcfunction(L, lua_module_dht_read);
         lua_setfield(L, -2, "read");
+        lua_pushcfunction(L, lua_module_dht_read_safe);
+        lua_setfield(L, -2, "read_safe");
         lua_pushcfunction(L, lua_module_dht_read_raw_method);
         lua_setfield(L, -2, "read_raw");
         lua_pushcfunction(L, lua_module_dht_read_temperature);
@@ -918,6 +1648,8 @@ static void lua_module_environmental_sensor_create_bme690_metatable(lua_State *L
         lua_setfield(L, -2, "__index");
         lua_pushcfunction(L, lua_module_bme690_read);
         lua_setfield(L, -2, "read");
+        lua_pushcfunction(L, lua_module_bme690_read_safe);
+        lua_setfield(L, -2, "read_safe");
         lua_pushcfunction(L, lua_module_bme690_read_temperature);
         lua_setfield(L, -2, "read_temperature");
         lua_pushcfunction(L, lua_module_bme690_read_pressure);
@@ -973,6 +1705,8 @@ static int lua_module_environmental_sensor_new(lua_State *L)
     if (backend_type == NULL) {
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690
         return lua_module_bme690_new(L);
+#elif CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+        return lua_module_shtc3_new(L);
 #elif CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_DHT
         return lua_module_dht_new(L);
 #else
@@ -983,6 +1717,14 @@ static int lua_module_environmental_sensor_new(lua_State *L)
     if (strcmp(backend_type, LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_BME690) == 0) {
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690
         return lua_module_bme690_new(L);
+#else
+        return luaL_error(L, "environmental_sensor backend '%s' is not enabled in menuconfig", backend_type);
+#endif
+    }
+
+    if (strcmp(backend_type, LUA_MODULE_ENVIRONMENTAL_SENSOR_TYPE_SHTC3) == 0) {
+#if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+        return lua_module_shtc3_new(L);
 #else
         return luaL_error(L, "environmental_sensor backend '%s' is not enabled in menuconfig", backend_type);
 #endif
@@ -1003,6 +1745,9 @@ int luaopen_environmental_sensor(lua_State *L)
 {
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_BME690
     lua_module_environmental_sensor_create_bme690_metatable(L);
+#endif
+#if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_SHTC3
+    lua_module_shtc3_create_metatable(L);
 #endif
 #if CONFIG_LUA_MODULE_ENVIRONMENTAL_SENSOR_BACKEND_DHT
     lua_module_dht_create_metatable(L);

--- a/components/lua_modules/lua_module_environmental_sensor/src/shtc3_math.c
+++ b/components/lua_modules/lua_module_environmental_sensor/src/shtc3_math.c
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "shtc3_math.h"
+
+#define SHTC3_CRC8_INIT       0xff
+#define SHTC3_CRC8_POLYNOMIAL 0x31
+#define SHTC3_RAW_MAX         65535.0f
+
+uint8_t shtc3_crc8(const uint8_t *data, size_t len)
+{
+    uint8_t crc = SHTC3_CRC8_INIT;
+
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; bit++) {
+            if ((crc & 0x80) != 0) {
+                crc = (uint8_t)((crc << 1) ^ SHTC3_CRC8_POLYNOMIAL);
+            } else {
+                crc = (uint8_t)(crc << 1);
+            }
+        }
+    }
+
+    return crc;
+}
+
+float shtc3_raw_to_celsius(uint16_t raw)
+{
+    return -45.0f + (175.0f * (float)raw / SHTC3_RAW_MAX);
+}
+
+float shtc3_raw_to_humidity(uint16_t raw)
+{
+    return 100.0f * (float)raw / SHTC3_RAW_MAX;
+}

--- a/components/lua_modules/lua_module_environmental_sensor/src/shtc3_math.h
+++ b/components/lua_modules/lua_module_environmental_sensor/src/shtc3_math.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t shtc3_crc8(const uint8_t *data, size_t len);
+float shtc3_raw_to_celsius(uint16_t raw);
+float shtc3_raw_to_humidity(uint16_t raw);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/lua_modules/lua_module_environmental_sensor/test/environmental_read.lua
+++ b/components/lua_modules/lua_module_environmental_sensor/test/environmental_read.lua
@@ -1,9 +1,9 @@
--- Environmental sensor demo: open a DUT and exercise all exported methods.
+-- Environmental sensor demo: open a DUT and print display-safe values.
 -- Optional args:
---   type="bme690"|"dht"
---   device="<board device name>"      -- for bme690
---   pin=<gpio>                         -- for dht
---   sensor_type="dht11"|"dht22"|...   -- for dht
+--   type="shtc3"|"bme690"|"dht"
+--   device="<board device name>"      -- for SHTC3/BME690
+--   pin=<gpio>                         -- for DHT
+--   sensor_type="dht11"|"dht22"|...   -- for DHT
 local environmental_sensor = require("environmental_sensor")
 
 local a = type(args) == "table" and args or {}
@@ -24,63 +24,90 @@ local function cleanup()
     end
 end
 
-local function run()
-    local backend_type
-    local opts
-
-    local function build_opts(kind)
-        if kind == "dht" then
-            return {
-                type = "dht",
-                pin = DHT_PIN,
-                sensor_type = DHT_SENSOR_TYPE,
-            }
-        end
+local function build_opts(kind)
+    if kind == "dht" then
         return {
-            type = "bme690",
-            device = DUT,
+            type = "dht",
+            pin = DHT_PIN,
+            sensor_type = DHT_SENSOR_TYPE,
         }
     end
+    return {
+        type = kind,
+        device = DUT,
+    }
+end
 
-    local function open_sensor(kind)
-        local open_opts = build_opts(kind)
-        if kind == "dht" then
-            print(string.format(
-                "[environmental_sensor] opening dut=%s type=%s pin=%d sensor_type=%s",
-                DUT, kind, DHT_PIN, DHT_SENSOR_TYPE
-            ))
-        else
-            print(string.format(
-                "[environmental_sensor] opening dut=%s type=%s",
-                DUT, kind
-            ))
+local function print_na(reason)
+    print("[environmental_sensor] sample_ok=false error=" .. tostring(reason))
+    print("temperature: N/A C")
+    print("humidity: N/A %")
+end
+
+local function open_sensor(kind)
+    local open_opts = build_opts(kind)
+    if kind == "dht" then
+        print(string.format(
+            "[environmental_sensor] opening dut=%s type=%s pin=%d sensor_type=%s",
+            DUT, kind, DHT_PIN, DHT_SENSOR_TYPE
+        ))
+    else
+        print(string.format(
+            "[environmental_sensor] opening dut=%s type=%s",
+            DUT, kind
+        ))
+    end
+    return environmental_sensor.new(open_opts), open_opts
+end
+
+local function open_first_available()
+    local kinds = REQUESTED_BACKEND_TYPE ~= nil and { REQUESTED_BACKEND_TYPE } or { "shtc3", "bme690", "dht" }
+    local last_err
+
+    for _, kind in ipairs(kinds) do
+        local ok, opened_sensor, open_opts = pcall(open_sensor, kind)
+        if ok then
+            return kind, opened_sensor, open_opts
         end
-        return environmental_sensor.new(open_opts), open_opts
+        last_err = opened_sensor
+        print(string.format("[environmental_sensor] %s open failed: %s", kind, tostring(opened_sensor)))
     end
 
-    if REQUESTED_BACKEND_TYPE ~= nil then
-        backend_type = REQUESTED_BACKEND_TYPE
-        sensor, opts = open_sensor(backend_type)
-    else
-        local ok, opened_sensor, open_opts = pcall(open_sensor, "bme690")
-        if ok then
-            backend_type = "bme690"
-            sensor = opened_sensor
-            opts = open_opts
-        else
-            print("[environmental_sensor] bme690 open failed, falling back to dht")
-            print("[environmental_sensor] fallback reason: " .. tostring(opened_sensor))
-            backend_type = "dht"
-            sensor, opts = open_sensor(backend_type)
-        end
+    return nil, nil, nil, last_err
+end
+
+local function run()
+    local backend_type, opts, open_err
+    backend_type, sensor, opts, open_err = open_first_available()
+    if not sensor then
+        print_na(open_err or "open failed")
+        return
     end
 
     print("[environmental_sensor] opened " .. sensor:name())
+    print("[environmental_sensor] calling sensor:read_safe()")
+    local sample = sensor:read_safe()
+    if not sample.ok then
+        print_na(sample.error or "read failed")
+        return
+    end
 
-    print("[environmental_sensor] calling sensor:read()")
-    local sample = sensor:read()
-    print(string.format("temperature: %.2f C", sample.temperature))
-    print(string.format("humidity: %.2f %%", sample.humidity))
+    print("[environmental_sensor] sample_ok=true")
+    print(string.format("temperature: %s C", sample.temperature_display))
+    print(string.format("humidity: %s %%", sample.humidity_display))
+
+    if sample.raw_temperature ~= nil then
+        print(string.format("raw_temperature=0x%04X", sample.raw_temperature))
+    end
+    if sample.raw_humidity ~= nil then
+        print(string.format("raw_humidity=0x%04X", sample.raw_humidity))
+    end
+    if sample.temperature_crc ~= nil then
+        print(string.format("temperature_crc=0x%02X", sample.temperature_crc))
+    end
+    if sample.humidity_crc ~= nil then
+        print(string.format("humidity_crc=0x%02X", sample.humidity_crc))
+    end
 
     print("[environmental_sensor] calling sensor:read_temperature()")
     local temperature = sensor:read_temperature()
@@ -94,7 +121,7 @@ local function run()
         print("[environmental_sensor] calling sensor:read_raw()")
         local temp_raw, humidity_raw = sensor:read_raw()
         print(string.format("raw_temperature=%d raw_humidity=%d", temp_raw, humidity_raw))
-    else
+    elseif backend_type == "bme690" then
         print("[environmental_sensor] calling sensor:read_pressure()")
         local pressure = sensor:read_pressure()
         print(string.format("pressure_only: %.2f Pa", pressure))
@@ -108,31 +135,35 @@ local function run()
 
         print("[environmental_sensor] calling sensor:variant_id()")
         print(string.format("variant_id: %d", sensor:variant_id()))
+    elseif backend_type == "shtc3" then
+        print("[environmental_sensor] calling sensor:product_id()")
+        print(string.format("product_id: 0x%04X", sensor:product_id()))
+    end
 
-        if sample.pressure ~= nil then
-            print(string.format("pressure: %.2f Pa", sample.pressure))
-        end
-        if sample.gas_resistance ~= nil then
-            print(string.format("gas resistance: %.2f ohm", sample.gas_resistance))
-        end
-        if sample.status ~= nil then
-            print(string.format("status: 0x%02X", sample.status))
-        end
-        if sample.gas_index ~= nil then
-            print(string.format("gas_index: %d", sample.gas_index))
-        end
-        if sample.meas_index ~= nil then
-            print(string.format("meas_index: %d", sample.meas_index))
-        end
+    if sample.pressure ~= nil then
+        print(string.format("pressure: %.2f Pa", sample.pressure))
+    end
+    if sample.gas_resistance ~= nil then
+        print(string.format("gas resistance: %.2f ohm", sample.gas_resistance))
+    end
+    if sample.status ~= nil then
+        print(string.format("status: 0x%02X", sample.status))
+    end
+    if sample.gas_index ~= nil then
+        print(string.format("gas_index: %d", sample.gas_index))
+    end
+    if sample.meas_index ~= nil then
+        print(string.format("meas_index: %d", sample.meas_index))
     end
 
     print("[environmental_sensor] calling sensor:close()")
     sensor:close()
     sensor = nil
+    opts = nil
 end
 
 local ok, err = xpcall(run, debug.traceback)
 cleanup()
 if not ok then
-    error(err)
+    print_na(err)
 end

--- a/components/lua_modules/lua_module_environmental_sensor/test_shtc3_helpers.py
+++ b/components/lua_modules/lua_module_environmental_sensor/test_shtc3_helpers.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+COMPONENT = ROOT
+
+
+def test_shtc3_crc_and_conversion():
+    source = COMPONENT / "src" / "shtc3_math.c"
+    include_dir = COMPONENT / "src"
+    assert source.exists(), "SHTC3 math helper source is missing"
+
+    harness = r'''
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "shtc3_math.h"
+
+static int expect_u8(const char *name, uint8_t actual, uint8_t expected)
+{
+    if (actual != expected) {
+        fprintf(stderr, "%s: got 0x%02x expected 0x%02x\n", name, actual, expected);
+        return 1;
+    }
+    return 0;
+}
+
+static int expect_float(const char *name, float actual, float expected, float tolerance)
+{
+    if (fabsf(actual - expected) > tolerance) {
+        fprintf(stderr, "%s: got %.6f expected %.6f\n", name, actual, expected);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+    const uint8_t zero[] = {0x00, 0x00};
+    const uint8_t full[] = {0xff, 0xff};
+    const uint8_t sample[] = {0xbe, 0xef};
+
+    failures += expect_u8("crc zero", shtc3_crc8(zero, sizeof(zero)), 0x81);
+    failures += expect_u8("crc full", shtc3_crc8(full, sizeof(full)), 0xac);
+    failures += expect_u8("crc sample", shtc3_crc8(sample, sizeof(sample)), 0x92);
+    failures += expect_float("temp min", shtc3_raw_to_celsius(0x0000), -45.0f, 0.001f);
+    failures += expect_float("temp max", shtc3_raw_to_celsius(0xffff), 130.0f, 0.001f);
+    failures += expect_float("humidity min", shtc3_raw_to_humidity(0x0000), 0.0f, 0.001f);
+    failures += expect_float("humidity max", shtc3_raw_to_humidity(0xffff), 100.0f, 0.001f);
+    return failures == 0 ? 0 : 1;
+}
+'''
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        harness_path = tmp_path / "shtc3_math_harness.c"
+        binary_path = tmp_path / "shtc3_math_harness"
+        harness_path.write_text(harness)
+        subprocess.run(
+            [
+                "cc",
+                "-std=c11",
+                "-Wall",
+                "-Wextra",
+                "-Werror",
+                "-I",
+                str(include_dir),
+                str(harness_path),
+                str(source),
+                "-lm",
+                "-o",
+                str(binary_path),
+            ],
+            check=True,
+        )
+        subprocess.run([str(binary_path)], check=True)
+
+
+def test_example_script_uses_safe_display_values():
+    script = (COMPONENT / "test" / "environmental_read.lua").read_text()
+    assert "read_safe" in script
+    assert "N/A" in script
+    assert "temperature_display" in script
+    assert "humidity_display" in script
+
+
+if __name__ == "__main__":
+    test_shtc3_crc_and_conversion()
+    test_example_script_uses_safe_display_values()

--- a/docs/src/content/docs/en/reference-cap/lua-modules.mdx
+++ b/docs/src/content/docs/en/reference-cap/lua-modules.mdx
@@ -41,7 +41,7 @@ Pure Lua modules may provide only managed resources such as `lib/`, `test/`, and
 | `delay` | `lua_module_delay` | `delay.delay_ms(n)` helpers |
 | `dht` | `lua_module_dht` | DHT-family temperature and humidity reads |
 | `display` | `lua_module_display` | LCD drawing (text, primitives, JPEG/PNG) |
-| `environmental_sensor` | `lua_module_environmental_sensor` | BME690 temperature, humidity, pressure, and gas data |
+| `environmental_sensor` | `lua_module_environmental_sensor` | SHTC3/BME690/DHT temperature and humidity data, with BME690 pressure and gas data |
 | `event_publisher` | `lua_module_event_publisher` | Publish events from Lua into the Event Router |
 | `http_server` | `lua_module_http_server` | Publish static files and HTTP callbacks on the existing HTTP server |
 | `image` | `lua_module_image` | Generic image frame type, format conversion, resizing, and file I/O |

--- a/docs/src/content/docs/zh-cn/reference-cap/lua-modules.mdx
+++ b/docs/src/content/docs/zh-cn/reference-cap/lua-modules.mdx
@@ -41,7 +41,7 @@ import { LinkCard } from 'starlight-theme-nova/components'
 | `delay` | `lua_module_delay` | `delay.delay_ms(n)` 毫秒级延时 |
 | `dht` | `lua_module_dht` | DHT 系列温湿度传感器读取 |
 | `display` | `lua_module_display` | LCD 屏幕绘图（文字、图形、JPEG/PNG） |
-| `environmental_sensor` | `lua_module_environmental_sensor` | BME690 温度、湿度、气压与气体数据读取 |
+| `environmental_sensor` | `lua_module_environmental_sensor` | SHTC3/BME690/DHT 温湿度读取，BME690 支持气压与气体数据 |
 | `event_publisher` | `lua_module_event_publisher` | 从 Lua 脚本向 Event Router 发布事件 |
 | `http_server` | `lua_module_http_server` | 在现有 HTTP 服务器上发布静态文件与 HTTP 回调 |
 | `image` | `lua_module_image` | 通用图像帧类型、格式转换、缩放与文件读写 |


### PR DESCRIPTION
## Summary
- Add SHTC3 support to the environmental_sensor Lua module, including CRC checks, conversion helpers, logs, and read_safe() display values.
- Configure Waveshare ESP32-S3-RLCD-4.2 to use the onboard SHTC3 at 7-bit I2C address 0x70.
- Update docs and the environmental sensor demo to show N/A instead of invalid readings when data cannot be read.

## Validation
- python3 components/lua_modules/lua_module_environmental_sensor/test_shtc3_helpers.py
- cd application/edge_agent && idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;components/gen_bmgr_codes/board_manager.defaults" build