### PR TITLE
feat(lua): add esp_now Lua module for ESP-NOW peer-to-peer messaging

### DIFF
--- a/components/common/app_claw/Kconfig
+++ b/components/common/app_claw/Kconfig
@@ -303,6 +303,16 @@ menu "App Claw Config"
                 Do not start the generic BLE Lua module advertising while BLE HID is
                 running.
 
+        config APP_CLAW_LUA_MODULE_ESP_NOW
+            bool "Enable ESP-NOW Lua module"
+            default n
+            depends on APP_CLAW_CAP_LUA
+            help
+                Enable the ESP-NOW Lua module (require("esp_now")) that wraps the
+                ESP-IDF ESP-NOW API for connectionless peer-to-peer messaging.
+                Requires the WiFi stack to be initialized and started, which the
+                application already does at boot via wifi_manager.
+
         config APP_CLAW_LUA_MODULE_CAMERA
             bool "Enable camera Lua module"
             default y if ESP_BOARD_DEV_CAMERA_SUPPORT

--- a/components/common/app_claw/app_lua_modules.c
+++ b/components/common/app_claw/app_lua_modules.c
@@ -56,6 +56,9 @@
 #if CONFIG_APP_CLAW_LUA_MODULE_BLE_HID
 #include "lua_module_ble_hid.h"
 #endif
+#if CONFIG_APP_CLAW_LUA_MODULE_ESP_NOW
+#include "lua_module_esp_now.h"
+#endif
 #if CONFIG_APP_CLAW_LUA_MODULE_CAMERA && defined(CONFIG_ESP_BOARD_DEV_CAMERA_SUPPORT)
 #include "lua_module_camera.h"
 #endif
@@ -421,6 +424,14 @@ static esp_err_t app_lua_register_ble_hid(const char *fatfs_base_path)
 }
 #endif
 
+#if CONFIG_APP_CLAW_LUA_MODULE_ESP_NOW
+static esp_err_t app_lua_register_esp_now(const char *fatfs_base_path)
+{
+    (void)fatfs_base_path;
+    return lua_module_esp_now_register();
+}
+#endif
+
 #if CONFIG_APP_CLAW_LUA_MODULE_CAMERA && defined(CONFIG_ESP_BOARD_DEV_CAMERA_SUPPORT)
 static esp_err_t app_lua_register_camera(const char *fatfs_base_path)
 {
@@ -637,6 +648,9 @@ static const app_lua_module_entry_t s_lua_module_entries[] = {
 #endif
 #if CONFIG_APP_CLAW_LUA_MODULE_BLE_HID
     { "ble_hid", "BLE HID", app_lua_register_ble_hid },
+#endif
+#if CONFIG_APP_CLAW_LUA_MODULE_ESP_NOW
+    { "esp_now", "ESP-NOW", app_lua_register_esp_now },
 #endif
 #if CONFIG_APP_CLAW_LUA_MODULE_CAMERA && defined(CONFIG_ESP_BOARD_DEV_CAMERA_SUPPORT)
     { "camera", "Camera", app_lua_register_camera },

--- a/components/common/app_claw/idf_component.yml
+++ b/components/common/app_claw/idf_component.yml
@@ -207,6 +207,12 @@ dependencies:
       - if: $CONFIG{APP_CLAW_LUA_MODULE_BLE_HID} == True
     path: ../../lua_modules/lua_module_ble_hid
 
+  lua_module_esp_now:
+    rules:
+      - if: $CONFIG{APP_CLAW_CAP_LUA} == True
+      - if: $CONFIG{APP_CLAW_LUA_MODULE_ESP_NOW} == True
+    path: ../../lua_modules/lua_module_esp_now
+
   lua_module_call_capability:
     rules:
       - if: $CONFIG{APP_CLAW_CAP_LUA} == True

--- a/components/lua_modules/lua_module_esp_now/CMakeLists.txt
+++ b/components/lua_modules/lua_module_esp_now/CMakeLists.txt
@@ -1,0 +1,18 @@
+if(CONFIG_APP_CLAW_LUA_MODULE_ESP_NOW)
+    set(lua_module_esp_now_srcs
+        "src/lua_module_esp_now.c"
+        "src/lua_module_esp_now_events.c"
+    )
+endif()
+
+idf_component_register(
+    SRCS
+        ${lua_module_esp_now_srcs}
+    INCLUDE_DIRS
+        "src"
+    REQUIRES
+        cap_lua
+        esp_wifi
+        freertos
+        heap
+)

--- a/components/lua_modules/lua_module_esp_now/README.md
+++ b/components/lua_modules/lua_module_esp_now/README.md
@@ -1,0 +1,118 @@
+# Lua ESP-NOW
+
+`require("esp_now")` wraps the ESP-IDF ESP-NOW API for connectionless,
+low-latency peer-to-peer messaging between Espressif devices without joining
+the same WiFi access point.
+
+The module is source-compatible with ESP-IDF 5.5.x and 6.x.
+
+## When To Use
+
+- Send short messages directly to another ESP device by its WiFi MAC address.
+- Broadcast small payloads to all listening devices on the same WiFi channel.
+- Build simple sensor/remote links that do not need TCP/IP.
+
+Use the `ble` module instead for phone/BLE-central interoperability, and normal
+sockets (via `http_server` / capabilities) for IP networking.
+
+## Core Rules
+
+- WiFi must already be initialized and started. In this firmware `wifi_manager`
+  does this at boot, so `esp_now.init()` succeeds without extra setup.
+- Every destination, including the broadcast address, must be added with
+  `esp_now.add_peer{...}` before `esp_now.send(...)`.
+- ESP-NOW peers must be on the same WiFi channel. When the device is connected
+  to an AP, the STA channel is fixed by the AP; add peers with `channel = 0`
+  (use current channel) unless you manage channels yourself. Use
+  `esp_now.get_channel()` to read the current channel and
+  `esp_now.set_channel(ch)` to align a standalone board to it (a manual channel
+  may not persist while STA-connected to an AP).
+- MAC addresses and payloads are raw Lua strings (not hex text). A MAC is
+  exactly 6 bytes.
+- Receive and send-complete notifications are delivered through an event queue.
+  Register a callback with `esp_now.on_event(fn)` and drain it in a loop with
+  `esp_now.process_events(timeout_ms)`.
+- Call `esp_now.deinit()` when finished to release the ESP-NOW driver.
+
+## How To Call
+
+- `esp_now.init()` -> `true` | `nil, err` : start ESP-NOW and register callbacks.
+- `esp_now.deinit()` -> `true` : stop ESP-NOW and clear queued events.
+- `esp_now.get_version()` -> `integer` | `nil, err` : ESP-NOW protocol version.
+- `esp_now.send(peer_mac, data)` -> `true` | `nil, err` : queue a frame to a peer.
+- `esp_now.add_peer(opts)` / `esp_now.mod_peer(opts)` -> `true` | `nil, err`.
+- `esp_now.del_peer(peer_mac)` -> `true` | `nil, err`.
+- `esp_now.get_peer(peer_mac)` -> `peer_table` | `nil, err`.
+- `esp_now.peer_exists(peer_mac)` -> `boolean`.
+- `esp_now.get_peer_num()` -> `{ total, encrypt }` | `nil, err`.
+- `esp_now.fetch_peers()` -> `array of peer_table`.
+- `esp_now.set_pmk(pmk)` -> `true` | `nil, err` : 16-byte primary master key.
+- `esp_now.set_wake_window(window)` -> `true` | `nil, err` : 0..65535.
+- `esp_now.set_channel(channel)` -> `true` | `nil, err` : lock the radio to a
+  primary channel (1..14) so a remote peer can be aligned to it.
+- `esp_now.get_channel()` -> `integer` | `nil, err` : current primary channel.
+- `esp_now.get_mac([ifidx])` -> `6-byte string` | `nil, err` : interface MAC
+  (defaults to `esp_now.IFIDX.STA`) that a peer can target.
+- `esp_now.on_event(fn_or_nil)` -> `true` : set or clear the event callback.
+- `esp_now.process_events(timeout_ms)` -> `integer` : events dispatched.
+- `esp_now.stats()` -> table with runtime counters.
+
+### `add_peer` / `mod_peer` options
+
+| Field       | Type            | Default            | Notes                                   |
+|-------------|-----------------|--------------------|-----------------------------------------|
+| `peer_addr` | 6-byte string   | required           | Peer WiFi MAC.                          |
+| `channel`   | integer 0..14   | `0`                | `0` = current channel.                  |
+| `ifidx`     | integer         | `esp_now.IFIDX.STA`| `IFIDX.STA` or `IFIDX.AP`.              |
+| `encrypt`   | boolean         | `false`            | Auto-enabled when `lmk` is set.         |
+| `lmk`       | 16-byte string  | none               | Local master key for encrypted peer.    |
+
+### Constants
+
+- `esp_now.BROADCAST_MAC` : 6-byte broadcast address (`FF:FF:FF:FF:FF:FF`).
+- `esp_now.MAX_DATA_LEN` : maximum payload length for `send`.
+- `esp_now.IFIDX` : `{ STA, AP }`.
+- `esp_now.SEND_STATUS` : `{ SUCCESS = 0, FAIL = 1 }`.
+
+## Events
+
+`esp_now.on_event(fn)` receives one table per event:
+
+- `recv` : `{ type = "recv", src_mac, dst_mac, data, rssi, channel }`.
+- `send` : `{ type = "send", peer_mac, status, success }` where `status` is
+  `esp_now.SEND_STATUS.SUCCESS` or `.FAIL` and `success` is a boolean.
+
+## Minimal Broadcast Example
+
+```lua
+local esp_now = require("esp_now")
+
+assert(esp_now.init())
+assert(esp_now.add_peer({ peer_addr = esp_now.BROADCAST_MAC }))
+
+esp_now.on_event(function(ev)
+    if ev.type == "recv" then
+        print("from", ev.src_mac, "rssi", ev.rssi, "data", ev.data)
+    elseif ev.type == "send" then
+        print("send success:", ev.success)
+    end
+end)
+
+assert(esp_now.send(esp_now.BROADCAST_MAC, "hello"))
+
+for _ = 1, 50 do
+    esp_now.process_events(100)
+end
+
+esp_now.deinit()
+```
+
+## Common Errors
+
+- `espnow_not_init` : call `esp_now.init()` first.
+- `espnow_peer_not_found` : add the peer before sending.
+- `espnow_peer_list_full` : too many peers; delete unused ones.
+- `espnow_channel_mismatch` : peer is on a different channel. Both devices must
+  share the same 2.4 GHz channel; while connected to an AP this device follows
+  the AP's channel (see `esp_now.get_channel()`).
+- `espnow_invalid_state` : WiFi is not initialized/started.

--- a/components/lua_modules/lua_module_esp_now/skills/esp_now/SKILL.md
+++ b/components/lua_modules/lua_module_esp_now/skills/esp_now/SKILL.md
@@ -1,0 +1,137 @@
+---
+{
+  "name": "esp_now",
+  "description": "Use ESP-NOW on ESP-Claw: send or broadcast short messages directly to nearby Espressif devices by MAC address, receive frames, manage peers, and process ESP-NOW events. Connectionless, no WiFi AP join needed.",
+  "metadata": {
+    "cap_groups": [
+      "cap_lua"
+    ],
+    "manage_mode": "readonly"
+  }
+}
+---
+
+# ESP-NOW Skill (lua_module_esp_now)
+
+This skill describes how an Agent controls ESP-NOW on ESP-Claw via Lua scripts.
+The module is a thin adapter over the ESP-IDF ESP-NOW API and works on
+ESP-IDF 5.5.x and 6.x.
+
+ESP-NOW is a connectionless protocol for sending short payloads directly to
+another Espressif device by its WiFi MAC address, or broadcasting to all
+listeners on the same WiFi channel. It does not require the devices to join the
+same access point.
+
+## Capabilities
+
+- Initialize / deinitialize ESP-NOW (`esp_now.init` / `esp_now.deinit`).
+- Send a unicast or broadcast frame (`esp_now.send`).
+- Manage peers (`add_peer`, `mod_peer`, `del_peer`, `get_peer`, `peer_exists`,
+  `get_peer_num`, `fetch_peers`).
+- Optional encryption (`set_pmk`, per-peer `lmk`) and low-power wake window
+  (`set_wake_window`).
+- Read/align the WiFi channel and read the interface MAC (`get_channel`,
+  `set_channel`, `get_mac`) so a standalone peer board can be matched.
+- Unified event queue: `esp_now.on_event(fn)` + `esp_now.process_events(ms)` for
+  received frames and send-complete status.
+- Diagnostics via `esp_now.stats()`.
+
+## Core Rules
+
+- WiFi is already initialized and started by the firmware at boot, so
+  `esp_now.init()` works without extra WiFi setup. If WiFi is somehow down,
+  `esp_now.init()` returns `nil, "espnow_invalid_state"`.
+- A peer (including `esp_now.BROADCAST_MAC`) must be added with
+  `esp_now.add_peer{...}` before `esp_now.send(...)`, otherwise send returns
+  `nil, "espnow_peer_not_found"`.
+- Peers must share the same WiFi channel. When connected to an AP the STA
+  channel is fixed; add peers with `channel = 0` to use the current channel.
+  Read the current channel with `esp_now.get_channel()` and align a standalone
+  board with `esp_now.set_channel(ch)` (a manual channel may not persist while
+  STA-connected to an AP).
+- MAC addresses and payloads are raw byte strings, not hex text. A MAC is
+  exactly 6 bytes.
+- If a script fails, report the returned error code to the user directly; do not
+  retry blindly with changed arguments.
+- If sends never succeed or no frames arrive, the likely cause is a WiFi channel
+  mismatch. Tell the user both devices must share the same 2.4 GHz channel, report
+  `esp_now.get_channel()`, and note this device follows its AP's channel. Leave the
+  fix to the user; do not auto-change channels or add retry loops.
+
+## Quick-start entry points
+
+Listen for incoming ESP-NOW frames and print them (also prints this device MAC
+so a peer can target it):
+
+```text
+lua --run --path builtin/skills/esp_now/scripts/start_espnow_listener.lua
+```
+
+Broadcast a one-off message to all listeners on the current channel:
+
+```text
+lua --run --path builtin/skills/esp_now/scripts/broadcast_espnow.lua
+```
+
+Edit the `CONFIG` table at the top of each script before running.
+
+## API summary
+
+See the module document (`esp_now.md`) for full signatures. All fallible calls
+return `true` / a value on success, or `nil, "error_code"` on recoverable
+failure; type errors raise a Lua error.
+
+- `esp_now.init()`, `esp_now.deinit()`, `esp_now.get_version()`
+- `esp_now.send(peer_mac, data)`
+- `esp_now.add_peer{ peer_addr=, channel=, ifidx=, encrypt=, lmk= }`
+- `esp_now.mod_peer{...}`, `esp_now.del_peer(mac)`, `esp_now.get_peer(mac)`
+- `esp_now.peer_exists(mac)`, `esp_now.get_peer_num()`, `esp_now.fetch_peers()`
+- `esp_now.set_pmk(pmk16)`, `esp_now.set_wake_window(window)`
+- `esp_now.set_channel(channel)`, `esp_now.get_channel()`, `esp_now.get_mac([ifidx])`
+- `esp_now.on_event(fn)`, `esp_now.process_events(timeout_ms)`, `esp_now.stats()`
+
+## Constants
+
+- `esp_now.BROADCAST_MAC` : 6-byte broadcast MAC.
+- `esp_now.MAX_DATA_LEN` : maximum `send` payload length.
+- `esp_now.IFIDX` : `{ STA, AP }`.
+- `esp_now.SEND_STATUS` : `{ SUCCESS = 0, FAIL = 1 }`.
+
+## Events
+
+Register one callback with `esp_now.on_event(fn)` and poll with
+`esp_now.process_events(timeout_ms)`:
+
+| `ev.type` | Key fields |
+|-----------|-----------|
+| `recv` | `src_mac`, `dst_mac`, `data`, `rssi`, `channel` |
+| `send` | `peer_mac`, `status`, `success` |
+
+```lua
+local esp_now = require("esp_now")
+esp_now.on_event(function(ev)
+    if ev.type == "recv" then
+        print("recv from", ev.src_mac, ev.data)
+    elseif ev.type == "send" then
+        print("send success", ev.success)
+    end
+end)
+while true do
+    esp_now.process_events(100)
+end
+```
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `espnow_not_init` | Call `esp_now.init()` first |
+| `espnow_invalid_state` | WiFi stack is not initialized/started |
+| `espnow_invalid_arg` | Invalid argument passed to ESP-NOW |
+| `espnow_no_mem` | Out of memory |
+| `espnow_peer_list_full` | Peer list is full |
+| `espnow_peer_not_found` | Peer not added before use |
+| `espnow_peer_exists` | Peer already added |
+| `espnow_interface_mismatch` | Peer interface does not match WiFi mode |
+| `espnow_channel_mismatch` | Peer channel does not match the current channel |
+| `espnow_internal` | ESP-NOW internal error |

--- a/components/lua_modules/lua_module_esp_now/skills/esp_now/scripts/broadcast_espnow.lua
+++ b/components/lua_modules/lua_module_esp_now/skills/esp_now/scripts/broadcast_espnow.lua
@@ -1,0 +1,57 @@
+-- ESP-NOW one-off broadcast entry point for Agent calls.
+--
+-- Initializes ESP-NOW, adds the broadcast peer, sends a single broadcast
+-- message, waits for the send-complete event, then tears down.
+--
+-- Usage:
+--   lua --run --path builtin/skills/esp_now/scripts/broadcast_espnow.lua
+
+local CONFIG = {
+    message       = "hello from esp-claw",
+    channel       = 0,   -- 0 = use current WiFi channel
+    event_poll_ms = 100,
+    wait_cycles   = 20,
+}
+
+local esp_now = require("esp_now")
+
+local function log(msg)
+    print("[espnow_broadcast] " .. msg)
+end
+
+local function assert_ok(ok, err)
+    if not ok then
+        error(tostring(err))
+    end
+    return ok
+end
+
+local done = false
+
+assert_ok(esp_now.init())
+
+assert_ok(esp_now.on_event(function(ev)
+    if ev.type == "send" then
+        log("send complete success=" .. tostring(ev.success))
+        done = true
+    end
+end))
+
+assert_ok(esp_now.add_peer({
+    peer_addr = esp_now.BROADCAST_MAC,
+    channel = CONFIG.channel,
+    ifidx = esp_now.IFIDX.STA,
+}))
+
+log("broadcasting: " .. CONFIG.message)
+assert_ok(esp_now.send(esp_now.BROADCAST_MAC, CONFIG.message))
+
+for _ = 1, CONFIG.wait_cycles do
+    esp_now.process_events(CONFIG.event_poll_ms)
+    if done then
+        break
+    end
+end
+
+esp_now.deinit()
+log("done")

--- a/components/lua_modules/lua_module_esp_now/skills/esp_now/scripts/start_espnow_listener.lua
+++ b/components/lua_modules/lua_module_esp_now/skills/esp_now/scripts/start_espnow_listener.lua
@@ -1,0 +1,69 @@
+-- ESP-NOW listener entry point for Agent calls.
+--
+-- Initializes ESP-NOW, registers the broadcast peer so broadcast frames are
+-- accepted, prints this device's WiFi MAC, and runs an event loop printing
+-- received frames until the Lua runtime requests a stop.
+--
+-- Usage:
+--   lua --run --path builtin/skills/esp_now/scripts/start_espnow_listener.lua
+
+local CONFIG = {
+    channel       = 0,   -- 0 = use current WiFi channel
+    event_poll_ms = 100,
+}
+
+local esp_now = require("esp_now")
+
+local function log(msg)
+    print("[espnow_listener] " .. msg)
+end
+
+local function assert_ok(ok, err)
+    if not ok then
+        error(tostring(err))
+    end
+    return ok
+end
+
+local function mac_to_hex(mac)
+    if type(mac) ~= "string" or #mac ~= 6 then
+        return "??:??:??:??:??:??"
+    end
+    return string.format("%02x:%02x:%02x:%02x:%02x:%02x",
+        mac:byte(1), mac:byte(2), mac:byte(3),
+        mac:byte(4), mac:byte(5), mac:byte(6))
+end
+
+local function on_event(ev)
+    if ev.type == "recv" then
+        log("recv from=" .. mac_to_hex(ev.src_mac)
+            .. " rssi=" .. tostring(ev.rssi)
+            .. " ch=" .. tostring(ev.channel)
+            .. " len=" .. tostring(#ev.data)
+            .. " data=" .. tostring(ev.data))
+    elseif ev.type == "send" then
+        log("send peer=" .. mac_to_hex(ev.peer_mac)
+            .. " success=" .. tostring(ev.success))
+    end
+end
+
+log("initializing ESP-NOW")
+assert_ok(esp_now.init())
+
+-- Accept broadcast frames.
+assert_ok(esp_now.add_peer({
+    peer_addr = esp_now.BROADCAST_MAC,
+    channel = CONFIG.channel,
+    ifidx = esp_now.IFIDX.STA,
+}))
+
+assert_ok(esp_now.on_event(on_event))
+
+local local_mac = esp_now.get_mac()
+log("local mac=" .. mac_to_hex(local_mac) .. " (share this with the peer board)")
+log("current channel=" .. tostring(esp_now.get_channel()))
+log("ESP-NOW version=" .. tostring(esp_now.get_version()))
+log("entering event loop (poll every " .. CONFIG.event_poll_ms .. " ms)")
+while true do
+    esp_now.process_events(CONFIG.event_poll_ms)
+end

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.c
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.c
@@ -1,0 +1,627 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lua_module_esp_now_priv.h"
+
+#include "cap_lua.h"
+
+const char *TAG = "lua_espnow";
+
+lua_espnow_runtime_t s_espnow_rt = {
+    .event_callback_ref = LUA_NOREF,
+};
+
+/* ------------------------------------------------------------------ */
+/* Runtime lock and error helpers                                     */
+/* ------------------------------------------------------------------ */
+
+esp_err_t lua_espnow_runtime_ensure(void)
+{
+    if (s_espnow_rt.mutex == NULL) {
+        s_espnow_rt.mutex = xSemaphoreCreateRecursiveMutex();
+        if (s_espnow_rt.mutex == NULL) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+    return ESP_OK;
+}
+
+void lua_espnow_runtime_lock(void)
+{
+    if (lua_espnow_runtime_ensure() != ESP_OK) {
+        return;
+    }
+    (void)xSemaphoreTakeRecursive(s_espnow_rt.mutex, portMAX_DELAY);
+}
+
+void lua_espnow_runtime_unlock(void)
+{
+    if (s_espnow_rt.mutex) {
+        (void)xSemaphoreGiveRecursive(s_espnow_rt.mutex);
+    }
+}
+
+static const char *lua_espnow_err_name(esp_err_t err)
+{
+    switch (err) {
+    case ESP_OK:
+        return NULL;
+    case ESP_ERR_ESPNOW_NOT_INIT:
+        return "espnow_not_init";
+    case ESP_ERR_ESPNOW_ARG:
+        return "espnow_invalid_arg";
+    case ESP_ERR_ESPNOW_NO_MEM:
+        return "espnow_no_mem";
+    case ESP_ERR_ESPNOW_FULL:
+        return "espnow_peer_list_full";
+    case ESP_ERR_ESPNOW_NOT_FOUND:
+        return "espnow_peer_not_found";
+    case ESP_ERR_ESPNOW_EXIST:
+        return "espnow_peer_exists";
+    case ESP_ERR_ESPNOW_IF:
+        return "espnow_interface_mismatch";
+    case ESP_ERR_ESPNOW_CHAN:
+        return "espnow_channel_mismatch";
+    case ESP_ERR_ESPNOW_INTERNAL:
+        return "espnow_internal";
+    case ESP_ERR_INVALID_STATE:
+        return "espnow_invalid_state";
+    case ESP_ERR_NO_MEM:
+        return "espnow_no_mem";
+    default:
+        return esp_err_to_name(err);
+    }
+}
+
+int lua_espnow_push_ok_or_err(lua_State *L, esp_err_t err)
+{
+    if (err == ESP_OK) {
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+    lua_pushnil(L);
+    lua_pushstring(L, lua_espnow_err_name(err));
+    return 2;
+}
+
+/* ------------------------------------------------------------------ */
+/* Argument parsing helpers                                           */
+/* ------------------------------------------------------------------ */
+
+/* Read a required 6-byte raw-string MAC from the given stack index. */
+static void lua_espnow_check_mac(lua_State *L, int index, uint8_t out_mac[ESP_NOW_ETH_ALEN])
+{
+    size_t len = 0;
+    const char *mac = luaL_checklstring(L, index, &len);
+
+    if (len != ESP_NOW_ETH_ALEN) {
+        luaL_error(L, "mac must be a 6-byte raw string");
+    }
+    memcpy(out_mac, mac, ESP_NOW_ETH_ALEN);
+}
+
+/* Ensure ESP-NOW has been initialized before a peer/data operation. */
+static bool lua_espnow_is_inited(void)
+{
+    bool inited;
+
+    lua_espnow_runtime_lock();
+    inited = s_espnow_rt.inited;
+    lua_espnow_runtime_unlock();
+    return inited;
+}
+
+/*
+ * Parse an options table (at stack index 1) into an esp_now_peer_info_t.
+ *   { peer_addr = <6 bytes>, channel = <int>, ifidx = <0|1>,
+ *     encrypt = <bool>, lmk = <16 bytes> }
+ */
+static int lua_espnow_parse_peer(lua_State *L, esp_now_peer_info_t *peer)
+{
+    memset(peer, 0, sizeof(*peer));
+
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "peer_addr");
+    {
+        size_t len = 0;
+        const char *addr = luaL_checklstring(L, -1, &len);
+        if (len != ESP_NOW_ETH_ALEN) {
+            return luaL_error(L, "peer_addr must be a 6-byte raw string");
+        }
+        memcpy(peer->peer_addr, addr, ESP_NOW_ETH_ALEN);
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "channel");
+    if (!lua_isnil(L, -1)) {
+        lua_Integer channel = luaL_checkinteger(L, -1);
+        if (channel < 0 || channel > 14) {
+            return luaL_error(L, "channel must be 0..14");
+        }
+        peer->channel = (uint8_t)channel;
+    }
+    lua_pop(L, 1);
+
+    peer->ifidx = WIFI_IF_STA;
+    lua_getfield(L, 1, "ifidx");
+    if (!lua_isnil(L, -1)) {
+        lua_Integer ifidx = luaL_checkinteger(L, -1);
+        if (ifidx != WIFI_IF_STA && ifidx != WIFI_IF_AP) {
+            return luaL_error(L, "ifidx must be esp_now.IFIDX.STA or esp_now.IFIDX.AP");
+        }
+        peer->ifidx = (wifi_interface_t)ifidx;
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "lmk");
+    if (!lua_isnil(L, -1)) {
+        size_t len = 0;
+        const char *lmk = luaL_checklstring(L, -1, &len);
+        if (len != ESP_NOW_KEY_LEN) {
+            return luaL_error(L, "lmk must be a %d-byte raw string", ESP_NOW_KEY_LEN);
+        }
+        memcpy(peer->lmk, lmk, ESP_NOW_KEY_LEN);
+        peer->encrypt = true;
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "encrypt");
+    if (!lua_isnil(L, -1)) {
+        peer->encrypt = lua_toboolean(L, -1);
+    }
+    lua_pop(L, 1);
+
+    return 0;
+}
+
+static void lua_espnow_push_peer(lua_State *L, const esp_now_peer_info_t *peer)
+{
+    lua_newtable(L);
+    lua_pushlstring(L, (const char *)peer->peer_addr, ESP_NOW_ETH_ALEN);
+    lua_setfield(L, -2, "peer_addr");
+    lua_pushinteger(L, peer->channel);
+    lua_setfield(L, -2, "channel");
+    lua_pushinteger(L, peer->ifidx);
+    lua_setfield(L, -2, "ifidx");
+    lua_pushboolean(L, peer->encrypt);
+    lua_setfield(L, -2, "encrypt");
+}
+
+/* ------------------------------------------------------------------ */
+/* Lifecycle                                                          */
+/* ------------------------------------------------------------------ */
+
+static int lua_espnow_init(lua_State *L)
+{
+    esp_err_t err;
+    wifi_mode_t mode;
+
+    if (lua_espnow_runtime_ensure() != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_NO_MEM);
+    }
+
+    /* ESP-NOW requires the WiFi stack to be initialized and started. In this
+     * firmware wifi_manager brings WiFi up before Lua runs; fail clearly if
+     * that is not the case instead of returning an opaque internal error. */
+    err = esp_wifi_get_mode(&mode);
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_INVALID_STATE);
+    }
+
+    lua_espnow_runtime_lock();
+    if (s_espnow_rt.inited) {
+        lua_espnow_runtime_unlock();
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+    if (s_event_queue == NULL) {
+        s_event_queue = xQueueCreate(LUA_ESPNOW_EVENT_QUEUE_LEN, sizeof(lua_espnow_event_t *));
+        if (s_event_queue == NULL) {
+            lua_espnow_runtime_unlock();
+            return lua_espnow_push_ok_or_err(L, ESP_ERR_NO_MEM);
+        }
+    }
+    lua_espnow_runtime_unlock();
+
+    err = esp_now_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_now_init failed: %s", esp_err_to_name(err));
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+
+    err = esp_now_register_recv_cb(lua_espnow_recv_cb);
+    if (err != ESP_OK) {
+        esp_now_deinit();
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    err = esp_now_register_send_cb(lua_espnow_send_cb);
+    if (err != ESP_OK) {
+        esp_now_unregister_recv_cb();
+        esp_now_deinit();
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+
+    lua_espnow_runtime_lock();
+    s_espnow_rt.inited = true;
+    lua_espnow_runtime_unlock();
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+static int lua_espnow_deinit(lua_State *L)
+{
+    if (!lua_espnow_is_inited()) {
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+
+    esp_now_unregister_recv_cb();
+    esp_now_unregister_send_cb();
+    esp_now_deinit();
+
+    lua_espnow_runtime_lock();
+    s_espnow_rt.inited = false;
+    lua_espnow_runtime_unlock();
+
+    lua_espnow_events_clear();
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+static int lua_espnow_get_version(lua_State *L)
+{
+    uint32_t version = 0;
+    esp_err_t err = esp_now_get_version(&version);
+
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    lua_pushinteger(L, (lua_Integer)version);
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Data path                                                          */
+/* ------------------------------------------------------------------ */
+
+static int lua_espnow_send(lua_State *L)
+{
+    uint8_t mac[ESP_NOW_ETH_ALEN];
+    size_t len = 0;
+    const char *data;
+    esp_err_t err;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_check_mac(L, 1, mac);
+    data = luaL_checklstring(L, 2, &len);
+    if (len == 0) {
+        return luaL_error(L, "data must be a non-empty string");
+    }
+
+    err = esp_now_send(mac, (const uint8_t *)data, len);
+    return lua_espnow_push_ok_or_err(L, err);
+}
+
+/* ------------------------------------------------------------------ */
+/* Peer management                                                    */
+/* ------------------------------------------------------------------ */
+
+static int lua_espnow_add_peer(lua_State *L)
+{
+    esp_now_peer_info_t peer;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_parse_peer(L, &peer);
+    return lua_espnow_push_ok_or_err(L, esp_now_add_peer(&peer));
+}
+
+static int lua_espnow_mod_peer(lua_State *L)
+{
+    esp_now_peer_info_t peer;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_parse_peer(L, &peer);
+    return lua_espnow_push_ok_or_err(L, esp_now_mod_peer(&peer));
+}
+
+static int lua_espnow_del_peer(lua_State *L)
+{
+    uint8_t mac[ESP_NOW_ETH_ALEN];
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_check_mac(L, 1, mac);
+    return lua_espnow_push_ok_or_err(L, esp_now_del_peer(mac));
+}
+
+static int lua_espnow_get_peer(lua_State *L)
+{
+    uint8_t mac[ESP_NOW_ETH_ALEN];
+    esp_now_peer_info_t peer;
+    esp_err_t err;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_check_mac(L, 1, mac);
+    err = esp_now_get_peer(mac, &peer);
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    lua_espnow_push_peer(L, &peer);
+    return 1;
+}
+
+static int lua_espnow_peer_exists(lua_State *L)
+{
+    uint8_t mac[ESP_NOW_ETH_ALEN];
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_espnow_check_mac(L, 1, mac);
+    lua_pushboolean(L, esp_now_is_peer_exist(mac));
+    return 1;
+}
+
+static int lua_espnow_get_peer_num(lua_State *L)
+{
+    esp_now_peer_num_t num = { 0 };
+    esp_err_t err;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    err = esp_now_get_peer_num(&num);
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    lua_newtable(L);
+    lua_pushinteger(L, num.total_num);
+    lua_setfield(L, -2, "total");
+    lua_pushinteger(L, num.encrypt_num);
+    lua_setfield(L, -2, "encrypt");
+    return 1;
+}
+
+static int lua_espnow_fetch_peers(lua_State *L)
+{
+    esp_now_peer_info_t peer;
+    bool from_head = true;
+    int count = 0;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    lua_newtable(L);
+    while (esp_now_fetch_peer(from_head, &peer) == ESP_OK) {
+        from_head = false;
+        lua_espnow_push_peer(L, &peer);
+        lua_rawseti(L, -2, ++count);
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Security / low power                                               */
+/* ------------------------------------------------------------------ */
+
+static int lua_espnow_set_pmk(lua_State *L)
+{
+    size_t len = 0;
+    const char *pmk;
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    pmk = luaL_checklstring(L, 1, &len);
+    if (len != ESP_NOW_KEY_LEN) {
+        return luaL_error(L, "pmk must be a %d-byte raw string", ESP_NOW_KEY_LEN);
+    }
+    return lua_espnow_push_ok_or_err(L, esp_now_set_pmk((const uint8_t *)pmk));
+}
+
+static int lua_espnow_set_wake_window(lua_State *L)
+{
+    lua_Integer window = luaL_checkinteger(L, 1);
+
+    if (!lua_espnow_is_inited()) {
+        return lua_espnow_push_ok_or_err(L, ESP_ERR_ESPNOW_NOT_INIT);
+    }
+    if (window < 0 || window > UINT16_MAX) {
+        return luaL_error(L, "window must be 0..65535");
+    }
+    return lua_espnow_push_ok_or_err(L, esp_now_set_wake_window((uint16_t)window));
+}
+
+/* ------------------------------------------------------------------ */
+/* WiFi radio helpers (channel / MAC)                                 */
+/* ------------------------------------------------------------------ */
+
+/*
+ * esp_now.set_channel(channel) -> true | nil, err
+ *
+ * Lock the WiFi radio to a primary channel (1..14) so a peer board can be
+ * aligned to the same channel. ESP-NOW frames are exchanged on the current
+ * channel, so both ends must match. Requires the WiFi stack to be started.
+ * Note: if this device is STA-connected to an AP, the driver keeps the AP's
+ * channel and a manual override may not persist.
+ */
+static int lua_espnow_set_channel(lua_State *L)
+{
+    lua_Integer channel = luaL_checkinteger(L, 1);
+
+    if (channel < 1 || channel > 14) {
+        return luaL_error(L, "channel must be 1..14");
+    }
+    return lua_espnow_push_ok_or_err(
+        L, esp_wifi_set_channel((uint8_t)channel, WIFI_SECOND_CHAN_NONE));
+}
+
+/* esp_now.get_channel() -> primary_channel(int) | nil, err */
+static int lua_espnow_get_channel(lua_State *L)
+{
+    uint8_t primary = 0;
+    wifi_second_chan_t second = WIFI_SECOND_CHAN_NONE;
+    esp_err_t err = esp_wifi_get_channel(&primary, &second);
+
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    lua_pushinteger(L, (lua_Integer)primary);
+    return 1;
+}
+
+/*
+ * esp_now.get_mac([ifidx]) -> 6-byte raw string | nil, err
+ *
+ * Return the interface MAC used for ESP-NOW addressing. Defaults to the STA
+ * interface, matching the default peer ifidx, so a remote peer can target
+ * this value (or learn it from a received frame's src_mac).
+ */
+static int lua_espnow_get_mac(lua_State *L)
+{
+    uint8_t mac[ESP_NOW_ETH_ALEN] = { 0 };
+    wifi_interface_t ifidx = WIFI_IF_STA;
+    esp_err_t err;
+
+    if (!lua_isnoneornil(L, 1)) {
+        lua_Integer v = luaL_checkinteger(L, 1);
+        if (v != WIFI_IF_STA && v != WIFI_IF_AP) {
+            return luaL_error(L, "ifidx must be esp_now.IFIDX.STA or esp_now.IFIDX.AP");
+        }
+        ifidx = (wifi_interface_t)v;
+    }
+
+    err = esp_wifi_get_mac(ifidx, mac);
+    if (err != ESP_OK) {
+        return lua_espnow_push_ok_or_err(L, err);
+    }
+    lua_pushlstring(L, (const char *)mac, ESP_NOW_ETH_ALEN);
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Introspection                                                      */
+/* ------------------------------------------------------------------ */
+
+static int lua_espnow_stats(lua_State *L)
+{
+    lua_espnow_runtime_lock();
+    lua_newtable(L);
+    lua_pushboolean(L, s_espnow_rt.inited);
+    lua_setfield(L, -2, "inited");
+    lua_pushboolean(L, s_event_callback_ref != LUA_NOREF);
+    lua_setfield(L, -2, "callback_set");
+    lua_pushinteger(L, s_espnow_rt.recv_count);
+    lua_setfield(L, -2, "recv_count");
+    lua_pushinteger(L, s_espnow_rt.send_count);
+    lua_setfield(L, -2, "send_count");
+    lua_pushinteger(L, s_event_dropped);
+    lua_setfield(L, -2, "event_dropped");
+    lua_pushinteger(L, ESP_NOW_MAX_DATA_LEN);
+    lua_setfield(L, -2, "max_data_len");
+    lua_espnow_runtime_unlock();
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Constant tables                                                    */
+/* ------------------------------------------------------------------ */
+
+static void lua_espnow_register_constants(lua_State *L)
+{
+    static const uint8_t broadcast[ESP_NOW_ETH_ALEN] = {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
+
+    lua_pushlstring(L, (const char *)broadcast, sizeof(broadcast));
+    lua_setfield(L, -2, "BROADCAST_MAC");
+
+    lua_pushinteger(L, ESP_NOW_MAX_DATA_LEN);
+    lua_setfield(L, -2, "MAX_DATA_LEN");
+
+    lua_newtable(L);
+    lua_pushinteger(L, WIFI_IF_STA);
+    lua_setfield(L, -2, "STA");
+    lua_pushinteger(L, WIFI_IF_AP);
+    lua_setfield(L, -2, "AP");
+    lua_setfield(L, -2, "IFIDX");
+
+    lua_newtable(L);
+    lua_pushinteger(L, ESP_NOW_SEND_SUCCESS);
+    lua_setfield(L, -2, "SUCCESS");
+    lua_pushinteger(L, ESP_NOW_SEND_FAIL);
+    lua_setfield(L, -2, "FAIL");
+    lua_setfield(L, -2, "SEND_STATUS");
+}
+
+/* ------------------------------------------------------------------ */
+/* Module registration                                                */
+/* ------------------------------------------------------------------ */
+
+int luaopen_esp_now(lua_State *L)
+{
+    if (lua_espnow_runtime_ensure() != ESP_OK) {
+        return luaL_error(L, "esp_now runtime init failed");
+    }
+    lua_newtable(L);
+    lua_pushcfunction(L, lua_espnow_init);
+    lua_setfield(L, -2, "init");
+    lua_pushcfunction(L, lua_espnow_deinit);
+    lua_setfield(L, -2, "deinit");
+    lua_pushcfunction(L, lua_espnow_get_version);
+    lua_setfield(L, -2, "get_version");
+    lua_pushcfunction(L, lua_espnow_send);
+    lua_setfield(L, -2, "send");
+    lua_pushcfunction(L, lua_espnow_add_peer);
+    lua_setfield(L, -2, "add_peer");
+    lua_pushcfunction(L, lua_espnow_mod_peer);
+    lua_setfield(L, -2, "mod_peer");
+    lua_pushcfunction(L, lua_espnow_del_peer);
+    lua_setfield(L, -2, "del_peer");
+    lua_pushcfunction(L, lua_espnow_get_peer);
+    lua_setfield(L, -2, "get_peer");
+    lua_pushcfunction(L, lua_espnow_peer_exists);
+    lua_setfield(L, -2, "peer_exists");
+    lua_pushcfunction(L, lua_espnow_get_peer_num);
+    lua_setfield(L, -2, "get_peer_num");
+    lua_pushcfunction(L, lua_espnow_fetch_peers);
+    lua_setfield(L, -2, "fetch_peers");
+    lua_pushcfunction(L, lua_espnow_set_pmk);
+    lua_setfield(L, -2, "set_pmk");
+    lua_pushcfunction(L, lua_espnow_set_wake_window);
+    lua_setfield(L, -2, "set_wake_window");
+    lua_pushcfunction(L, lua_espnow_set_channel);
+    lua_setfield(L, -2, "set_channel");
+    lua_pushcfunction(L, lua_espnow_get_channel);
+    lua_setfield(L, -2, "get_channel");
+    lua_pushcfunction(L, lua_espnow_get_mac);
+    lua_setfield(L, -2, "get_mac");
+    lua_pushcfunction(L, lua_espnow_on_event);
+    lua_setfield(L, -2, "on_event");
+    lua_pushcfunction(L, lua_espnow_process_events);
+    lua_setfield(L, -2, "process_events");
+    lua_pushcfunction(L, lua_espnow_stats);
+    lua_setfield(L, -2, "stats");
+    lua_espnow_register_constants(L);
+    return 1;
+}
+
+esp_err_t lua_module_esp_now_register(void)
+{
+    return cap_lua_register_module(LUA_MODULE_ESP_NOW_NAME, luaopen_esp_now);
+}

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.c
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.c
@@ -157,6 +157,12 @@ static int lua_espnow_parse_peer(lua_State *L, esp_now_peer_info_t *peer)
     }
     lua_pop(L, 1);
 
+    lua_getfield(L, 1, "encrypt");
+    if (!lua_isnil(L, -1)) {
+        peer->encrypt = lua_toboolean(L, -1);
+    }
+    lua_pop(L, 1);
+
     lua_getfield(L, 1, "lmk");
     if (!lua_isnil(L, -1)) {
         size_t len = 0;
@@ -166,12 +172,6 @@ static int lua_espnow_parse_peer(lua_State *L, esp_now_peer_info_t *peer)
         }
         memcpy(peer->lmk, lmk, ESP_NOW_KEY_LEN);
         peer->encrypt = true;
-    }
-    lua_pop(L, 1);
-
-    lua_getfield(L, 1, "encrypt");
-    if (!lua_isnil(L, -1)) {
-        peer->encrypt = lua_toboolean(L, -1);
     }
     lua_pop(L, 1);
 
@@ -211,6 +211,7 @@ static int lua_espnow_init(lua_State *L)
     if (err != ESP_OK) {
         return lua_espnow_push_ok_or_err(L, ESP_ERR_INVALID_STATE);
     }
+    (void)mode;
 
     lua_espnow_runtime_lock();
     if (s_espnow_rt.inited) {
@@ -302,8 +303,8 @@ static int lua_espnow_send(lua_State *L)
     }
     lua_espnow_check_mac(L, 1, mac);
     data = luaL_checklstring(L, 2, &len);
-    if (len == 0) {
-        return luaL_error(L, "data must be a non-empty string");
+    if (len == 0 || len > ESP_NOW_MAX_DATA_LEN) {
+        return luaL_error(L, "data length must be 1..%d bytes", ESP_NOW_MAX_DATA_LEN);
     }
 
     err = esp_now_send(mac, (const uint8_t *)data, len);

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.h
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_err.h"
+#include "lua.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int luaopen_esp_now(lua_State *L);
+esp_err_t lua_module_esp_now_register(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_compat.h
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_compat.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/*
+ * ESP-IDF 5.5.x / 6.x compatibility helpers for the ESP-NOW Lua module.
+ *
+ * The only ESP-NOW API surface that changed shape between the supported IDF
+ * ranges is the send callback's tx_info. Since IDF 5.5 the send callback is
+ *   void (*)(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
+ * and esp_now_send_info_t is a typedef of wifi_tx_info_t, whose des_addr /
+ * src_addr are pointers to 6-byte MAC addresses in both 5.5.x and 6.x.
+ *
+ * Everything else the module uses (recv callback esp_now_recv_info_t, peer
+ * management, esp_now_set_pmk / set_wake_window, WIFI_IF_STA / WIFI_IF_AP) is
+ * source-compatible across 5.5.x and 6.x, so no version guards are needed
+ * elsewhere. The module deliberately avoids APIs removed in 6.0 such as the
+ * ESP_IF_WIFI_* macros and esp_wifi_config_espnow_rate().
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_wifi.h"
+#include "esp_now.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Copy the destination MAC (6 bytes) from a send-callback tx_info.
+ *
+ * Isolated here so the one layout-sensitive access lives in a single place.
+ *
+ * @param tx_info Send callback information pointer.
+ * @param out_mac Output buffer of at least 6 bytes.
+ * @return true if a destination address was available and copied.
+ */
+static inline bool lua_espnow_send_info_dest(const esp_now_send_info_t *tx_info, uint8_t out_mac[6])
+{
+    if (tx_info == NULL || tx_info->des_addr == NULL) {
+        return false;
+    }
+    memcpy(out_mac, tx_info->des_addr, ESP_NOW_ETH_ALEN);
+    return true;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_events.c
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_events.c
@@ -1,0 +1,271 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+
+#include "esp_heap_caps.h"
+
+#include "lua_module_esp_now_priv.h"
+
+lua_espnow_event_t *lua_espnow_event_alloc(void)
+{
+    return heap_caps_calloc_prefer(1,
+                                   sizeof(lua_espnow_event_t),
+                                   2,
+                                   MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
+                                   MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+}
+
+void lua_espnow_event_free(lua_espnow_event_t *event)
+{
+    if (!event) {
+        return;
+    }
+    heap_caps_free(event->data);
+    heap_caps_free(event);
+}
+
+esp_err_t lua_espnow_event_set_data(lua_espnow_event_t *event, const uint8_t *data, size_t data_len)
+{
+    if (!event) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    heap_caps_free(event->data);
+    event->data = NULL;
+    event->data_len = 0;
+    if (data_len == 0) {
+        return ESP_OK;
+    }
+    if (!data) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    event->data = heap_caps_malloc_prefer(data_len,
+                                          2,
+                                          MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
+                                          MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (!event->data) {
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(event->data, data, data_len);
+    event->data_len = data_len;
+    return ESP_OK;
+}
+
+void lua_espnow_events_clear(void)
+{
+    lua_espnow_event_t *item;
+
+    lua_espnow_runtime_lock();
+    if (!s_event_queue) {
+        lua_espnow_runtime_unlock();
+        return;
+    }
+    while (xQueueReceive(s_event_queue, &item, 0) == pdTRUE) {
+        lua_espnow_event_free(item);
+    }
+    lua_espnow_runtime_unlock();
+}
+
+void lua_espnow_event_enqueue(lua_espnow_event_t *event)
+{
+    uint32_t dropped_total = 0;
+    bool dropped_event = false;
+
+    if (!event) {
+        return;
+    }
+    lua_espnow_runtime_lock();
+    if (!s_event_queue) {
+        lua_espnow_runtime_unlock();
+        lua_espnow_event_free(event);
+        return;
+    }
+    if (xQueueSend(s_event_queue, &event, 0) != pdTRUE) {
+        s_event_dropped++;
+        dropped_total = s_event_dropped;
+        dropped_event = true;
+    }
+    lua_espnow_runtime_unlock();
+    if (dropped_event) {
+        ESP_LOGW(TAG, "ESP-NOW event queue full, dropped event type=%d total=%" PRIu32,
+                 event->type, dropped_total);
+        lua_espnow_event_free(event);
+    }
+}
+
+void lua_espnow_recv_cb(const esp_now_recv_info_t *info, const uint8_t *data, int len)
+{
+    lua_espnow_event_t *event;
+
+    if (!info || !info->src_addr || len < 0) {
+        return;
+    }
+
+    event = lua_espnow_event_alloc();
+    if (!event) {
+        ESP_LOGW(TAG, "ESP-NOW recv event alloc failed len=%d", len);
+        return;
+    }
+    event->type = LUA_ESPNOW_EVENT_RECV;
+    memcpy(event->src_mac, info->src_addr, ESP_NOW_ETH_ALEN);
+    if (info->des_addr) {
+        memcpy(event->dst_mac, info->des_addr, ESP_NOW_ETH_ALEN);
+    }
+    if (info->rx_ctrl) {
+        event->rssi = info->rx_ctrl->rssi;
+        event->channel = info->rx_ctrl->channel;
+    }
+    if (len > 0 && lua_espnow_event_set_data(event, data, (size_t)len) != ESP_OK) {
+        ESP_LOGW(TAG, "ESP-NOW recv payload copy failed len=%d", len);
+        lua_espnow_event_free(event);
+        return;
+    }
+
+    lua_espnow_runtime_lock();
+    s_espnow_rt.recv_count++;
+    lua_espnow_runtime_unlock();
+    lua_espnow_event_enqueue(event);
+}
+
+void lua_espnow_send_cb(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
+{
+    lua_espnow_event_t *event = lua_espnow_event_alloc();
+
+    if (!event) {
+        ESP_LOGW(TAG, "ESP-NOW send event alloc failed");
+        return;
+    }
+    event->type = LUA_ESPNOW_EVENT_SEND;
+    event->send_status = (int)status;
+    (void)lua_espnow_send_info_dest(tx_info, event->dst_mac);
+
+    lua_espnow_runtime_lock();
+    s_espnow_rt.send_count++;
+    lua_espnow_runtime_unlock();
+    lua_espnow_event_enqueue(event);
+}
+
+static void lua_espnow_event_push_lua(lua_State *L, const lua_espnow_event_t *event)
+{
+    lua_newtable(L);
+    if (event->type == LUA_ESPNOW_EVENT_RECV) {
+        lua_pushstring(L, "recv");
+        lua_setfield(L, -2, "type");
+        lua_pushlstring(L, (const char *)event->src_mac, sizeof(event->src_mac));
+        lua_setfield(L, -2, "src_mac");
+        lua_pushlstring(L, (const char *)event->dst_mac, sizeof(event->dst_mac));
+        lua_setfield(L, -2, "dst_mac");
+        lua_pushlstring(L, event->data ? (const char *)event->data : "", event->data_len);
+        lua_setfield(L, -2, "data");
+        lua_pushinteger(L, event->rssi);
+        lua_setfield(L, -2, "rssi");
+        lua_pushinteger(L, event->channel);
+        lua_setfield(L, -2, "channel");
+    } else {
+        lua_pushstring(L, "send");
+        lua_setfield(L, -2, "type");
+        lua_pushlstring(L, (const char *)event->dst_mac, sizeof(event->dst_mac));
+        lua_setfield(L, -2, "peer_mac");
+        lua_pushinteger(L, event->send_status);
+        lua_setfield(L, -2, "status");
+        lua_pushboolean(L, event->send_status == ESP_NOW_SEND_SUCCESS);
+        lua_setfield(L, -2, "success");
+    }
+}
+
+static bool lua_espnow_event_receive(lua_espnow_event_t **event, TickType_t wait)
+{
+    QueueHandle_t queue = s_event_queue;
+
+    if (!queue || s_event_callback_ref == LUA_NOREF) {
+        return false;
+    }
+    return xQueueReceive(queue, event, wait) == pdTRUE;
+}
+
+static bool lua_espnow_event_push_callback(lua_State *L)
+{
+    int callback_ref = s_event_callback_ref;
+
+    if (callback_ref == LUA_NOREF) {
+        return false;
+    }
+    lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+    if (!lua_isfunction(L, -1)) {
+        lua_pop(L, 1);
+        luaL_unref(L, LUA_REGISTRYINDEX, callback_ref);
+        if (s_event_callback_ref == callback_ref) {
+            s_event_callback_ref = LUA_NOREF;
+        }
+        lua_espnow_events_clear();
+        return false;
+    }
+    return true;
+}
+
+int lua_espnow_on_event(lua_State *L)
+{
+    if (lua_isnil(L, 1)) {
+        if (s_event_callback_ref != LUA_NOREF) {
+            luaL_unref(L, LUA_REGISTRYINDEX, s_event_callback_ref);
+            s_event_callback_ref = LUA_NOREF;
+        }
+        lua_espnow_events_clear();
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+    lua_pushvalue(L, 1);
+    if (s_event_callback_ref != LUA_NOREF) {
+        luaL_unref(L, LUA_REGISTRYINDEX, s_event_callback_ref);
+    }
+    s_event_callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    lua_espnow_events_clear();
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+int lua_espnow_process_events(lua_State *L)
+{
+    int timeout_ms = lua_isnoneornil(L, 1) ? 0 : (int)luaL_checkinteger(L, 1);
+    lua_espnow_event_t *event;
+    int processed = 0;
+    TickType_t first_wait;
+
+    if (timeout_ms < 0) {
+        timeout_ms = 0;
+    }
+    if (!s_event_queue || s_event_callback_ref == LUA_NOREF) {
+        lua_pushinteger(L, 0);
+        return 1;
+    }
+
+    first_wait = (timeout_ms > 0) ? pdMS_TO_TICKS(timeout_ms) : 0;
+
+    while (processed < LUA_ESPNOW_PROCESS_EVENTS_MAX) {
+        TickType_t wait = (processed == 0) ? first_wait : 0;
+
+        if (!lua_espnow_event_receive(&event, wait)) {
+            break;
+        }
+        if (!lua_espnow_event_push_callback(L)) {
+            lua_espnow_event_free(event);
+            break;
+        }
+        lua_espnow_event_push_lua(L, event);
+        lua_espnow_event_free(event);
+        if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
+            const char *msg = lua_tostring(L, -1);
+            ESP_LOGE(TAG, "ESP-NOW event callback error: %s", msg ? msg : "(nil)");
+            lua_pop(L, 1);
+        }
+        processed++;
+    }
+
+    lua_pushinteger(L, processed);
+    return 1;
+}

--- a/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_priv.h
+++ b/components/lua_modules/lua_module_esp_now/src/lua_module_esp_now_priv.h
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "lua_module_esp_now.h"
+#include "lua_module_esp_now_compat.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_now.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
+#include "lauxlib.h"
+#include "lua.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LUA_MODULE_ESP_NOW_NAME "esp_now"
+
+#define LUA_ESPNOW_EVENT_QUEUE_LEN 32
+#define LUA_ESPNOW_PROCESS_EVENTS_MAX 8
+
+/* Event kinds delivered to Lua via esp_now.on_event / esp_now.process_events. */
+typedef enum {
+    LUA_ESPNOW_EVENT_RECV,   /* A unicast/broadcast frame was received. */
+    LUA_ESPNOW_EVENT_SEND,   /* A previously issued esp_now.send completed. */
+} lua_espnow_event_type_t;
+
+/* Queued event payload; only fields relevant to type are populated. */
+typedef struct {
+    lua_espnow_event_type_t type;
+    uint8_t src_mac[ESP_NOW_ETH_ALEN];  /* RECV: sender MAC */
+    uint8_t dst_mac[ESP_NOW_ETH_ALEN];  /* RECV: dest MAC (unicast or broadcast); SEND: peer MAC */
+    int rssi;                           /* RECV: signal strength from rx_ctrl */
+    uint8_t channel;                    /* RECV: primary channel from rx_ctrl */
+    int send_status;                    /* SEND: ESP_NOW_SEND_SUCCESS(0) / ESP_NOW_SEND_FAIL(1) */
+    uint8_t *data;                      /* RECV: heap-allocated payload; NULL if empty */
+    size_t data_len;
+} lua_espnow_event_t;
+
+/* Module-wide runtime state shared by the Lua task and ESP-NOW/WiFi callbacks. */
+typedef struct {
+    SemaphoreHandle_t mutex;    /* Recursive mutex guarding queue/callback/state */
+    QueueHandle_t event_queue;  /* Queue of lua_espnow_event_t pointers */
+    int event_callback_ref;     /* LUA_REGISTRYINDEX ref to on_event callback; LUA_NOREF if unset */
+    uint32_t event_dropped;     /* Count of events dropped because the queue was full */
+    uint32_t recv_count;        /* Total received frames delivered to the queue */
+    uint32_t send_count;        /* Total send completions delivered to the queue */
+    bool inited;                /* esp_now.init() completed and callbacks registered */
+} lua_espnow_runtime_t;
+
+extern const char *TAG;
+extern lua_espnow_runtime_t s_espnow_rt;
+
+#define s_event_queue (s_espnow_rt.event_queue)
+#define s_event_callback_ref (s_espnow_rt.event_callback_ref)
+#define s_event_dropped (s_espnow_rt.event_dropped)
+
+/** @brief Create the runtime recursive mutex if not already allocated. */
+esp_err_t lua_espnow_runtime_ensure(void);
+
+/** @brief Take the runtime mutex; no-op if ensure failed. */
+void lua_espnow_runtime_lock(void);
+
+/** @brief Release the runtime mutex. */
+void lua_espnow_runtime_unlock(void);
+
+/**
+ * @brief Push a Lua return for an esp_err_t: true on ESP_OK, else nil + err string.
+ * @return Number of Lua values pushed (1 or 2).
+ */
+int lua_espnow_push_ok_or_err(lua_State *L, esp_err_t err);
+
+/** @brief Allocate a zeroed event struct from SPIRAM-preferred heap. */
+lua_espnow_event_t *lua_espnow_event_alloc(void);
+
+/** @brief Free an event struct and its optional payload. */
+void lua_espnow_event_free(lua_espnow_event_t *event);
+
+/** @brief Copy payload into event->data. */
+esp_err_t lua_espnow_event_set_data(lua_espnow_event_t *event, const uint8_t *data, size_t data_len);
+
+/** @brief Enqueue event and transfer ownership; drop/free if the queue is full. */
+void lua_espnow_event_enqueue(lua_espnow_event_t *event);
+
+/** @brief Drain and discard all queued events (under the runtime lock). */
+void lua_espnow_events_clear(void);
+
+/** @brief ESP-NOW receive callback (runs in the WiFi task). */
+void lua_espnow_recv_cb(const esp_now_recv_info_t *info, const uint8_t *data, int len);
+
+/** @brief ESP-NOW send-complete callback (runs in the WiFi task). */
+void lua_espnow_send_cb(const esp_now_send_info_t *tx_info, esp_now_send_status_t status);
+
+/**
+ * @brief Lua API: esp_now.on_event(fn_or_nil).
+ * Register or clear the single event callback and clear the queue.
+ */
+int lua_espnow_on_event(lua_State *L);
+
+/**
+ * @brief Lua API: esp_now.process_events(timeout_ms).
+ * Dispatch up to LUA_ESPNOW_PROCESS_EVENTS_MAX events to the registered callback.
+ */
+int lua_espnow_process_events(lua_State *L);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/lua_modules/lua_module_esp_now/test/test_esp_now.lua
+++ b/components/lua_modules/lua_module_esp_now/test/test_esp_now.lua
@@ -1,16 +1,29 @@
 -- ESP-NOW bring-up and self-test.
 --
 -- Verifies init, version, peer management, broadcast send, event processing,
--- and deinit. With two boards running this script, each device broadcasts a
--- greeting and prints any frames it receives from the other.
+-- encrypted-peer (lmk) handling, stats, and deinit. Runs on a single board:
+-- the send-complete path is asserted (broadcast link status is always success),
+-- while received frames are informational and only appear when a second board
+-- is broadcasting on the same channel.
 
 local LOG_PREFIX = "[espnow_test]"
 local MESSAGE = "ping from esp-claw"
 local POLL_MS = 100
 local LOOP_CYCLES = 50
 
+-- Fake unicast peer used to exercise peer-table and encryption handling. The
+-- locally-administered bit (0x02) keeps it out of any real device's range; we
+-- never transmit to it, so no second board is required.
+local TEST_PEER_MAC = string.char(0x02, 0x00, 0x00, 0x00, 0x00, 0x01)
+local TEST_PMK = "pmk_16byte_key!!" -- exactly 16 bytes
+local TEST_LMK = "1234567890abcdef" -- exactly 16 bytes
+
 local delay_ok, delay = pcall(require, "delay")
 local esp_now = require("esp_now")
+
+local recv_count = 0
+local send_count = 0
+local initialized = false
 
 local function log(msg)
     print(LOG_PREFIX .. " " .. msg)
@@ -43,58 +56,109 @@ local function mac_to_hex(mac)
         mac:byte(4), mac:byte(5), mac:byte(6))
 end
 
-local recv_count = 0
-local send_count = 0
+local function run()
+    -- init
+    assert_ok(esp_now.init())
+    initialized = true
+    log("init ok; version=" .. tostring(esp_now.get_version()))
 
--- init
-assert_ok(esp_now.init())
-log("init ok; version=" .. tostring(esp_now.get_version()))
+    -- radio helpers
+    local local_mac = assert_ok(esp_now.get_mac())
+    assert(#local_mac == 6, "get_mac must return a 6-byte string")
+    log("local mac=" .. mac_to_hex(local_mac))
+    local channel = assert_ok(esp_now.get_channel())
+    log("current channel=" .. tostring(channel))
 
--- radio helpers
-local local_mac = assert_ok(esp_now.get_mac())
-assert(#local_mac == 6, "get_mac must return a 6-byte string")
-log("local mac=" .. mac_to_hex(local_mac))
-local channel = assert_ok(esp_now.get_channel())
-log("current channel=" .. tostring(channel))
+    -- events
+    assert_ok(esp_now.on_event(function(ev)
+        if ev.type == "recv" then
+            recv_count = recv_count + 1
+            log("recv from=" .. mac_to_hex(ev.src_mac)
+                .. " rssi=" .. tostring(ev.rssi)
+                .. " data=" .. tostring(ev.data))
+        elseif ev.type == "send" then
+            send_count = send_count + 1
+            log("send success=" .. tostring(ev.success))
+        end
+    end))
 
--- events
-assert_ok(esp_now.on_event(function(ev)
-    if ev.type == "recv" then
-        recv_count = recv_count + 1
-        log("recv from=" .. mac_to_hex(ev.src_mac)
-            .. " rssi=" .. tostring(ev.rssi)
-            .. " data=" .. tostring(ev.data))
-    elseif ev.type == "send" then
-        send_count = send_count + 1
-        log("send success=" .. tostring(ev.success))
+    -- peer management
+    assert_ok(esp_now.add_peer({ peer_addr = esp_now.BROADCAST_MAC, channel = 0 }))
+    assert(esp_now.peer_exists(esp_now.BROADCAST_MAC), "broadcast peer should exist")
+
+    local num = assert_ok(esp_now.get_peer_num())
+    log("peer_num total=" .. tostring(num.total) .. " encrypt=" .. tostring(num.encrypt))
+
+    local peers = esp_now.fetch_peers()
+    log("fetch_peers count=" .. tostring(#peers))
+
+    local peer = assert_ok(esp_now.get_peer(esp_now.BROADCAST_MAC))
+    log("broadcast peer channel=" .. tostring(peer.channel) .. " ifidx=" .. tostring(peer.ifidx))
+
+    -- send
+    assert_ok(esp_now.send(esp_now.BROADCAST_MAC, MESSAGE))
+
+    -- event loop
+    for _ = 1, LOOP_CYCLES do
+        esp_now.process_events(POLL_MS)
+        sleep_ms(10)
     end
-end))
 
--- peer management
-assert_ok(esp_now.add_peer({ peer_addr = esp_now.BROADCAST_MAC, channel = 0 }))
-assert(esp_now.peer_exists(esp_now.BROADCAST_MAC), "broadcast peer should exist")
+    log("totals: recv=" .. tostring(recv_count) .. " send=" .. tostring(send_count))
+    assert(send_count >= 1, "expected at least one send-complete event")
 
-local num = assert_ok(esp_now.get_peer_num())
-log("peer_num total=" .. tostring(num.total) .. " encrypt=" .. tostring(num.encrypt))
+    -- encrypted peer: setting lmk must force encrypt=true regardless of the
+    -- encrypt flag. A PMK is set first so the encrypted peer is always accepted.
+    assert_ok(esp_now.set_pmk(TEST_PMK))
+    local before = assert_ok(esp_now.get_peer_num())
+    assert_ok(esp_now.add_peer({
+        peer_addr = TEST_PEER_MAC,
+        channel = 0,
+        lmk = TEST_LMK,
+        encrypt = false,
+    }))
+    local secure_peer = assert_ok(esp_now.get_peer(TEST_PEER_MAC))
+    assert(secure_peer.encrypt == true, "lmk should force encrypt=true")
 
-local peers = esp_now.fetch_peers()
-log("fetch_peers count=" .. tostring(#peers))
+    local after = assert_ok(esp_now.get_peer_num())
+    assert(after.total == before.total + 1, "total peer count should increase by 1")
+    assert(after.encrypt == before.encrypt + 1, "encrypt peer count should increase by 1")
 
-local peer = assert_ok(esp_now.get_peer(esp_now.BROADCAST_MAC))
-log("broadcast peer channel=" .. tostring(peer.channel) .. " ifidx=" .. tostring(peer.ifidx))
+    assert_ok(esp_now.del_peer(TEST_PEER_MAC))
+    assert(not esp_now.peer_exists(TEST_PEER_MAC), "test peer should be removed")
 
--- send
-assert_ok(esp_now.send(esp_now.BROADCAST_MAC, MESSAGE))
+    -- stats
+    local stats = assert_ok(esp_now.stats())
+    log("stats inited=" .. tostring(stats.inited)
+        .. " callback_set=" .. tostring(stats.callback_set)
+        .. " send_count=" .. tostring(stats.send_count)
+        .. " max_data_len=" .. tostring(stats.max_data_len))
+    assert(stats.inited == true, "stats.inited should be true")
+    assert(stats.callback_set == true, "stats.callback_set should be true")
+    assert(stats.send_count >= 1, "stats.send_count should be >= 1")
 
--- event loop
-for _ = 1, LOOP_CYCLES do
-    esp_now.process_events(POLL_MS)
-    sleep_ms(10)
+    -- cleanup
+    assert_ok(esp_now.del_peer(esp_now.BROADCAST_MAC))
+    assert_ok(esp_now.deinit())
+    initialized = false
+    log("Test Passed.")
 end
 
-log("totals: recv=" .. tostring(recv_count) .. " send=" .. tostring(send_count))
+-- Guarantees the driver is torn down even if an assertion fails mid-run, so a
+-- failed run does not leave ESP-NOW initialized with stale peers behind.
+local function cleanup()
+    if not initialized then
+        return
+    end
+    pcall(esp_now.del_peer, TEST_PEER_MAC)
+    pcall(esp_now.del_peer, esp_now.BROADCAST_MAC)
+    pcall(esp_now.deinit)
+    initialized = false
+end
 
--- cleanup
-assert_ok(esp_now.del_peer(esp_now.BROADCAST_MAC))
-assert_ok(esp_now.deinit())
-log("deinit ok; test complete")
+local ok, err = xpcall(run, debug.traceback)
+cleanup()
+if not ok then
+    log("ERROR: " .. tostring(err))
+    error(err)
+end

--- a/components/lua_modules/lua_module_esp_now/test/test_esp_now.lua
+++ b/components/lua_modules/lua_module_esp_now/test/test_esp_now.lua
@@ -1,0 +1,100 @@
+-- ESP-NOW bring-up and self-test.
+--
+-- Verifies init, version, peer management, broadcast send, event processing,
+-- and deinit. With two boards running this script, each device broadcasts a
+-- greeting and prints any frames it receives from the other.
+
+local LOG_PREFIX = "[espnow_test]"
+local MESSAGE = "ping from esp-claw"
+local POLL_MS = 100
+local LOOP_CYCLES = 50
+
+local delay_ok, delay = pcall(require, "delay")
+local esp_now = require("esp_now")
+
+local function log(msg)
+    print(LOG_PREFIX .. " " .. msg)
+end
+
+local function assert_ok(ok, err)
+    if not ok then
+        error(LOG_PREFIX .. " " .. tostring(err))
+    end
+    return ok
+end
+
+local function sleep_ms(ms)
+    if delay_ok and delay and type(delay.delay_ms) == "function" then
+        delay.delay_ms(ms)
+        return
+    end
+    if os and type(os.clock) == "function" then
+        local deadline = os.clock() + (ms / 1000)
+        while os.clock() < deadline do end
+    end
+end
+
+local function mac_to_hex(mac)
+    if type(mac) ~= "string" or #mac ~= 6 then
+        return "??"
+    end
+    return string.format("%02x:%02x:%02x:%02x:%02x:%02x",
+        mac:byte(1), mac:byte(2), mac:byte(3),
+        mac:byte(4), mac:byte(5), mac:byte(6))
+end
+
+local recv_count = 0
+local send_count = 0
+
+-- init
+assert_ok(esp_now.init())
+log("init ok; version=" .. tostring(esp_now.get_version()))
+
+-- radio helpers
+local local_mac = assert_ok(esp_now.get_mac())
+assert(#local_mac == 6, "get_mac must return a 6-byte string")
+log("local mac=" .. mac_to_hex(local_mac))
+local channel = assert_ok(esp_now.get_channel())
+log("current channel=" .. tostring(channel))
+
+-- events
+assert_ok(esp_now.on_event(function(ev)
+    if ev.type == "recv" then
+        recv_count = recv_count + 1
+        log("recv from=" .. mac_to_hex(ev.src_mac)
+            .. " rssi=" .. tostring(ev.rssi)
+            .. " data=" .. tostring(ev.data))
+    elseif ev.type == "send" then
+        send_count = send_count + 1
+        log("send success=" .. tostring(ev.success))
+    end
+end))
+
+-- peer management
+assert_ok(esp_now.add_peer({ peer_addr = esp_now.BROADCAST_MAC, channel = 0 }))
+assert(esp_now.peer_exists(esp_now.BROADCAST_MAC), "broadcast peer should exist")
+
+local num = assert_ok(esp_now.get_peer_num())
+log("peer_num total=" .. tostring(num.total) .. " encrypt=" .. tostring(num.encrypt))
+
+local peers = esp_now.fetch_peers()
+log("fetch_peers count=" .. tostring(#peers))
+
+local peer = assert_ok(esp_now.get_peer(esp_now.BROADCAST_MAC))
+log("broadcast peer channel=" .. tostring(peer.channel) .. " ifidx=" .. tostring(peer.ifidx))
+
+-- send
+assert_ok(esp_now.send(esp_now.BROADCAST_MAC, MESSAGE))
+
+-- event loop
+for _ = 1, LOOP_CYCLES do
+    esp_now.process_events(POLL_MS)
+    sleep_ms(10)
+end
+
+log("totals: recv=" .. tostring(recv_count) .. " send=" .. tostring(send_count))
+
+-- cleanup
+assert_ok(esp_now.del_peer(esp_now.BROADCAST_MAC))
+assert_ok(esp_now.deinit())
+log("deinit ok; test complete")


### PR DESCRIPTION
## Description

Add a new `esp_now` Lua module that wraps the ESP-IDF ESP-NOW API, enabling
connectionless, low-latency peer-to-peer messaging between Espressif devices
without joining the same AP. It is source-compatible with ESP-IDF 5.5.x and 6.x.

Motivation: give Lua scripts and skills a first-class way to build direct
device-to-device links (sensor/remote nodes, broadcast fan-out) that do not
need TCP/IP, complementing the existing `ble` and socket-based options.

What's included:
- Native module `lua_module_esp_now` exposing init/deinit, send, full peer
  management (add/mod/del/get/exists/fetch, peer counts), PMK/LMK encryption,
  channel and MAC helpers, and an event queue (`on_event` / `process_events`)
  delivering `recv` and `send` notifications.
- Constants `BROADCAST_MAC`, `MAX_DATA_LEN`, `IFIDX`, `SEND_STATUS` and a
  `stats()` counter table.
- Module registration and Kconfig wiring in `components/common/app_claw/`
  (`app_lua_modules.c`, `Kconfig`, `idf_component.yml`).
- `esp_now` skill (`SKILL.md`) with ready-to-run scripts
  `broadcast_espnow.lua` and `start_espnow_listener.lua`.
- Docs (`README.md`) covering API, options, events, and common errors.
- Self-test script `test/test_esp_now.lua`.

## Related

N/A

## Testing

- Built the firmware with the new module enabled and flashed to real hardware.
- Ran the module through a full end-to-end scenario: a simulated ESP-NOW
  temperature/humidity sensor node with auto-pairing and deep-sleep reporting,
  talking to ESP-Claw.
- Verified the complete flow: pairing (`PAIR_REQ` / `PAIR_RESP`) -> data
  reporting (`DATA`) -> acknowledgement (`ACK`) -> deep sleep -> wake and reuse.
- All four message types were sent and received correctly in both directions.
- Also exercised `test/test_esp_now.lua` for basic bring-up (init, version,
  peer management, broadcast send, event processing, deinit).

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.