### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ If this project helps you, please consider giving it a star. ⭐⭐⭐⭐⭐
 ### Star History
 
 <div align="center">
-  <a href="https://www.star-history.com/?repos=espressif%2Fesp-claw&type=date&legend=top-left">
+  <a href="https://star-history.dera.page/#espressif/esp-claw&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&legend=top-left" />
   </picture>
   </a>
 </div>

--- a/README_CN.md
+++ b/README_CN.md
@@ -181,11 +181,11 @@ ESP-Claw 目前仍处于活跃开发阶段，欢迎向我们提交 Issue 反馈�
 ### Star History
 
 <div align="center">
-  <a href="https://www.star-history.com/?repos=espressif%2Fesp-claw&type=date&legend=top-left">
+  <a href="https://star-history.dera.page/#espressif/esp-claw&type=date&legend=top-left">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=espressif/esp-claw&type=date&legend=top-left" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=espressif/esp-claw&type=date&legend=top-left" />
     </picture>
   </a>
 </div>


### PR DESCRIPTION
The star history chart in the README was broken and no longer rendered correctly due to GitHub stargazer API restrictions. This change updates the chart links and image sources so the project's star history is visible again.

The fix applies to both README.md and README_CN.md.