### PR TITLE
Add ChatGPT OAuth Codex Responses backend

### DIFF
--- a/application/edge_agent/components/http_server/CMakeLists.txt
+++ b/application/edge_agent/components/http_server/CMakeLists.txt
@@ -20,6 +20,7 @@ set(http_server_srcs
     "http_server_lua_modules_api.c"
     "http_server_status_api.c"
     "http_server_files_api.c"
+    "http_server_openai_api.c"
     "http_server_wechat_api.c"
     "http_server_webim_api.c"
     "http_server_json.c"

--- a/application/edge_agent/components/http_server/http_server_core.c
+++ b/application/edge_agent/components/http_server/http_server_core.c
@@ -97,6 +97,7 @@ esp_err_t http_server_start(void)
 #if CONFIG_APP_CLAW_LUA_MODULE_HTTP_SERVER
     ESP_RETURN_ON_ERROR(http_server_register_lua_app_routes(s_ctx.server), TAG, "Failed to register Lua app routes");
 #endif
+    ESP_RETURN_ON_ERROR(http_server_register_openai_routes(s_ctx.server), TAG, "Failed to register OpenAI routes");
     ESP_RETURN_ON_ERROR(http_server_register_wechat_routes(s_ctx.server), TAG, "Failed to register WeChat routes");
     ESP_RETURN_ON_ERROR(http_server_register_webim_routes(s_ctx.server), TAG, "Failed to register Web IM routes");
     ESP_RETURN_ON_ERROR(httpd_register_err_handler(s_ctx.server, HTTPD_404_NOT_FOUND, http_server_captive_404_handler),

--- a/application/edge_agent/components/http_server/http_server_openai_api.c
+++ b/application/edge_agent/components/http_server/http_server_openai_api.c
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "http_server_priv.h"
+
+static esp_err_t openai_send_status(
+    httpd_req_t *req,
+    const http_server_openai_login_status_t *status)
+{
+    cJSON *resp = cJSON_CreateObject();
+
+    if (!resp) {
+        httpd_resp_send_500(req);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddBoolToObject(resp, "ok", true);
+    cJSON_AddBoolToObject(resp, "active", status->active);
+    cJSON_AddBoolToObject(resp, "completed", status->completed);
+
+    http_server_json_add_string(resp,
+                                "status",
+                                status->status);
+
+    http_server_json_add_string(resp,
+                                "message",
+                                status->message);
+
+    http_server_json_add_string(resp,
+                                "user_code",
+                                status->user_code);
+
+    http_server_json_add_string(resp,
+                                "verification_url",
+                                status->verification_url);
+
+    cJSON_AddNumberToObject(resp,
+                            "interval",
+                            status->interval);
+
+    return http_server_send_json_response(req, resp);
+}
+
+static esp_err_t openai_login_start_handler(httpd_req_t *req)
+{
+    http_server_ctx_t *ctx = http_server_ctx();
+    http_server_openai_login_status_t status = {0};
+
+    esp_err_t err =
+        ctx->services.openai_login_start
+            ? ctx->services.openai_login_start()
+            : ESP_ERR_INVALID_STATE;
+
+    if (err != ESP_OK) {
+        return httpd_resp_send_err(
+            req,
+            HTTPD_500_INTERNAL_SERVER_ERROR,
+            "Failed to start OpenAI login");
+    }
+
+    err =
+        ctx->services.openai_login_get_status
+            ? ctx->services.openai_login_get_status(&status)
+            : ESP_ERR_INVALID_STATE;
+
+    if (err != ESP_OK) {
+        return httpd_resp_send_err(
+            req,
+            HTTPD_500_INTERNAL_SERVER_ERROR,
+            "Failed to read OpenAI login status");
+    }
+
+    return openai_send_status(req, &status);
+}
+
+static esp_err_t openai_login_status_handler(httpd_req_t *req)
+{
+    http_server_ctx_t *ctx = http_server_ctx();
+    http_server_openai_login_status_t status = {0};
+
+    esp_err_t err =
+        ctx->services.openai_login_get_status
+            ? ctx->services.openai_login_get_status(&status)
+            : ESP_ERR_INVALID_STATE;
+
+    if (err != ESP_OK) {
+        return httpd_resp_send_err(
+            req,
+            HTTPD_500_INTERNAL_SERVER_ERROR,
+            "Failed to read OpenAI login status");
+    }
+
+    return openai_send_status(req, &status);
+}
+
+static esp_err_t openai_login_cancel_handler(httpd_req_t *req)
+{
+    http_server_ctx_t *ctx = http_server_ctx();
+    http_server_openai_login_status_t status = {0};
+
+    esp_err_t err =
+        ctx->services.openai_login_cancel
+            ? ctx->services.openai_login_cancel()
+            : ESP_ERR_INVALID_STATE;
+
+    if (err != ESP_OK) {
+        return httpd_resp_send_err(
+            req,
+            HTTPD_500_INTERNAL_SERVER_ERROR,
+            "Failed to cancel OpenAI login");
+    }
+
+    err =
+        ctx->services.openai_login_get_status
+            ? ctx->services.openai_login_get_status(&status)
+            : ESP_ERR_INVALID_STATE;
+
+    if (err != ESP_OK) {
+        return httpd_resp_send_err(
+            req,
+            HTTPD_500_INTERNAL_SERVER_ERROR,
+            "Failed to read OpenAI login status");
+    }
+
+    return openai_send_status(req, &status);
+}
+
+esp_err_t http_server_register_openai_routes(httpd_handle_t server)
+{
+    const httpd_uri_t handlers[] = {
+        {
+            .uri = "/api/openai/login/start",
+            .method = HTTP_POST,
+            .handler = openai_login_start_handler
+        },
+        {
+            .uri = "/api/openai/login/status",
+            .method = HTTP_GET,
+            .handler = openai_login_status_handler
+        },
+        {
+            .uri = "/api/openai/login/cancel",
+            .method = HTTP_POST,
+            .handler = openai_login_cancel_handler
+        },
+    };
+
+    for (size_t i = 0;
+            i < sizeof(handlers) / sizeof(handlers[0]);
+            ++i) {
+        esp_err_t err =
+            httpd_register_uri_handler(server, &handlers[i]);
+
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    return ESP_OK;
+}

--- a/application/edge_agent/components/http_server/http_server_priv.h
+++ b/application/edge_agent/components/http_server/http_server_priv.h
@@ -53,6 +53,7 @@ esp_err_t http_server_register_files_routes(httpd_handle_t server);
 #if CONFIG_APP_CLAW_LUA_MODULE_HTTP_SERVER
 esp_err_t http_server_register_lua_app_routes(httpd_handle_t server);
 #endif
+esp_err_t http_server_register_openai_routes(httpd_handle_t server);
 esp_err_t http_server_register_wechat_routes(httpd_handle_t server);
 esp_err_t http_server_register_webim_routes(httpd_handle_t server);
 void http_server_webim_ws_fd_remove(int fd);

--- a/application/edge_agent/components/http_server/include/http_server.h
+++ b/application/edge_agent/components/http_server/include/http_server.h
@@ -39,10 +39,23 @@ typedef struct {
 } http_server_wechat_login_status_t;
 
 typedef struct {
+    bool active;
+    bool completed;
+    char status[32];
+    char message[160];
+    char user_code[32];
+    char verification_url[160];
+    uint32_t interval;
+} http_server_openai_login_status_t;
+
+typedef struct {
     esp_err_t (*load_config)(app_config_t *config);
     esp_err_t (*save_config)(const app_config_t *config);
     esp_err_t (*get_wifi_status)(http_server_wifi_status_t *status);
     esp_err_t (*restart_device)(void);
+    esp_err_t (*openai_login_start)(void);
+    esp_err_t (*openai_login_get_status)(http_server_openai_login_status_t *status);
+    esp_err_t (*openai_login_cancel)(void);
     esp_err_t (*wechat_login_start)(const char *account_id, bool force);
     esp_err_t (*wechat_login_get_status)(http_server_wechat_login_status_t *status);
     esp_err_t (*wechat_login_cancel)(void);

--- a/application/edge_agent/main/main.c
+++ b/application/edge_agent/main/main.c
@@ -7,6 +7,7 @@
 #include "app_fs.h"
 #include "claw_version.h"
 #include "claw_paths.h"
+#include "claw_openai_codex_auth.h"
 #include "edge_agent_version.h"
 #include <string.h>
 #include <stdlib.h>
@@ -92,6 +93,13 @@ static void on_wifi_state_changed(bool connected, void *user_ctx)
     esp_err_t err = app_claw_set_network_status(connected, ap_ssid);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Failed to update network UI: %s", esp_err_to_name(err));
+    }
+
+    if (connected) {
+        esp_err_t auth_err = claw_openai_codex_auth_restore_async();
+        if (auth_err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to restore ChatGPT auth: %s", esp_err_to_name(auth_err));
+        }
     }
 }
 
@@ -248,6 +256,57 @@ static esp_err_t main_wechat_login_mark_persisted(void)
 }
 #endif
 
+static esp_err_t main_openai_login_start(void)
+{
+    return claw_openai_codex_login_start();
+}
+
+static esp_err_t main_openai_login_get_status(
+    http_server_openai_login_status_t *status)
+{
+    claw_openai_codex_login_status_t raw = {0};
+
+    ESP_RETURN_ON_FALSE(
+        status,
+        ESP_ERR_INVALID_ARG,
+        TAG,
+        "OpenAI login status is NULL");
+
+    ESP_RETURN_ON_ERROR(
+        claw_openai_codex_login_get_status(&raw),
+        TAG,
+        "Failed to get OpenAI login status");
+
+    memset(status, 0, sizeof(*status));
+
+    status->active = raw.active;
+    status->completed = raw.completed;
+    status->interval = raw.interval;
+
+    strlcpy(status->status,
+            raw.status,
+            sizeof(status->status));
+
+    strlcpy(status->message,
+            raw.message,
+            sizeof(status->message));
+
+    strlcpy(status->user_code,
+            raw.user_code,
+            sizeof(status->user_code));
+
+    strlcpy(status->verification_url,
+            raw.verification_url,
+            sizeof(status->verification_url));
+
+    return ESP_OK;
+}
+
+static esp_err_t main_openai_login_cancel(void)
+{
+    return claw_openai_codex_login_cancel();
+}
+
 static esp_err_t init_nvs(void)
 {
     esp_err_t err = nvs_flash_init();
@@ -347,6 +406,9 @@ void app_main(void)
             .save_config = main_save_config,
             .get_wifi_status = main_get_wifi_status,
             .restart_device = main_restart_device,
+            .openai_login_start = main_openai_login_start,
+            .openai_login_get_status = main_openai_login_get_status,
+            .openai_login_cancel = main_openai_login_cancel,
 #if CONFIG_APP_CLAW_CAP_IM_WECHAT
             .wechat_login_start = main_wechat_login_start,
             .wechat_login_get_status = main_wechat_login_get_status,

--- a/components/claw_modules/claw_core/CMakeLists.txt
+++ b/components/claw_modules/claw_core/CMakeLists.txt
@@ -14,8 +14,11 @@ idf_component_register(
         "src/claw_core_llm.c"
         "src/llm/claw_llm_runtime.c"
         "src/llm/claw_llm_http_transport.c"
+        "src/llm/claw_openai_codex_auth.c"
+        "src/llm/claw_openai_codex_store.c"
         "src/llm/backends/claw_llm_backend_anthropic.c"
         "src/llm/backends/claw_llm_backend_openai_compatible.c"
+        "src/llm/backends/claw_llm_backend_openai_codex.c"
         "src/llm/backends/claw_llm_backend_custom.c"
         "src/llm/media/claw_media_pipeline.c"
     INCLUDE_DIRS
@@ -27,6 +30,7 @@ idf_component_register(
         esp-tls
         freertos
         mbedtls
+        nvs_flash
         claw_utils
     PRIV_REQUIRES
         claw_event_router

--- a/components/claw_modules/claw_core/include/claw_openai_codex_auth.h
+++ b/components/claw_modules/claw_core/include/claw_openai_codex_auth.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+typedef struct {
+    bool active;
+    bool completed;
+    char status[32];
+    char message[160];
+    char user_code[32];
+    char verification_url[160];
+    uint32_t interval;
+} claw_openai_codex_login_status_t;
+
+esp_err_t claw_openai_codex_auth_restore_async(void);
+esp_err_t claw_openai_codex_auth_get_session(char **out_access_token, char **out_account_id);
+esp_err_t claw_openai_codex_login_start(void);
+esp_err_t claw_openai_codex_login_get_status(claw_openai_codex_login_status_t *status);
+esp_err_t claw_openai_codex_login_cancel(void);

--- a/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_custom.c
+++ b/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_custom.c
@@ -10,6 +10,7 @@
 
 #include "llm/backends/claw_llm_backend_anthropic.h"
 #include "llm/backends/claw_llm_backend_openai_compatible.h"
+#include "llm/backends/claw_llm_backend_openai_codex.h"
 
 typedef struct custom_backend_registration_node {
     claw_llm_custom_backend_registration_t registration;
@@ -24,6 +25,7 @@ static const claw_llm_backend_registration_t *find_builtin_backend_registration(
 {
     static const builtin_backend_registration_getter_t getters[] = {
         claw_llm_backend_openai_compatible_registration,
+        claw_llm_backend_openai_codex_registration,
         claw_llm_backend_anthropic_registration,
     };
     size_t i;

--- a/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_openai_codex.c
+++ b/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_openai_codex.c
@@ -1,0 +1,843 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "llm/backends/claw_llm_backend_openai_codex.h"
+
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "claw_openai_codex_auth.h"
+#include "llm/claw_llm_http_transport.h"
+
+#define OPENAI_CODEX_RESPONSES_URL "https://chatgpt.com/backend-api/codex/responses"
+#define OPENAI_CODEX_DEFAULT_TIMEOUT_MS 120000
+#define OPENAI_CODEX_ORIGINATOR "esp_claw"
+#define OPENAI_CODEX_CLIENT_VERSION "0.1.0"
+#define OPENAI_CODEX_USER_AGENT "esp-claw/0.1.0"
+
+typedef struct {
+    char model[96];
+    uint32_t timeout_ms;
+} openai_codex_backend_ctx_t;
+
+static openai_codex_backend_ctx_t s_ctx;
+
+static char *dup_printf(const char *fmt, ...)
+{
+    va_list args, copy;
+    va_start(args, fmt);
+    va_copy(copy, args);
+    int needed = vsnprintf(NULL, 0, fmt, copy);
+    va_end(copy);
+    if (needed < 0) { va_end(args); return NULL; }
+    char *buf = calloc(1, (size_t)needed + 1U);
+    if (!buf) { va_end(args); return NULL; }
+    vsnprintf(buf, (size_t)needed + 1U, fmt, args);
+    va_end(args);
+    return buf;
+}
+
+static esp_err_t append_text(char **buffer, size_t *length, const char *text)
+{
+    if (!buffer || !length || !text) return ESP_ERR_INVALID_ARG;
+    size_t add = strlen(text);
+    if (!add) return ESP_OK;
+    char *grown = realloc(*buffer, *length + add + 1U);
+    if (!grown) return ESP_ERR_NO_MEM;
+    memcpy(grown + *length, text, add);
+    *length += add;
+    grown[*length] = '\0';
+    *buffer = grown;
+    return ESP_OK;
+}
+
+static char *message_text(cJSON *message)
+{
+    if (!message || !cJSON_IsObject(message)) return NULL;
+    cJSON *content = cJSON_GetObjectItemCaseSensitive(message, "content");
+    if (cJSON_IsString(content) && content->valuestring) return strdup(content->valuestring);
+    if (!cJSON_IsArray(content)) return NULL;
+
+    char *text = NULL;
+    size_t length = 0;
+    cJSON *part = NULL;
+    cJSON_ArrayForEach(part, content) {
+        if (!cJSON_IsObject(part)) continue;
+        cJSON *t = cJSON_GetObjectItemCaseSensitive(part, "text");
+        if (!cJSON_IsString(t) || !t->valuestring) continue;
+        if (append_text(&text, &length, t->valuestring) != ESP_OK) { free(text); return NULL; }
+    }
+    return text;
+}
+
+
+static esp_err_t add_responses_message(cJSON *input, cJSON *source)
+{
+    if (!input || !source || !cJSON_IsArray(input) || !cJSON_IsObject(source)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    cJSON *codex_output =
+        cJSON_GetObjectItemCaseSensitive(source, "_codex_output");
+
+    if (cJSON_IsArray(codex_output)) {
+        cJSON *saved = NULL;
+
+        cJSON_ArrayForEach(saved, codex_output) {
+            cJSON *dup = cJSON_Duplicate(saved, true);
+            if (!dup) return ESP_ERR_NO_MEM;
+            cJSON_AddItemToArray(input, dup);
+        }
+
+        return ESP_OK;
+    }
+
+    const char *role =
+        cJSON_GetStringValue(
+            cJSON_GetObjectItemCaseSensitive(source, "role"));
+
+    if (!role || !role[0]) return ESP_OK;
+
+    if (strcmp(role, "tool") == 0 ||
+        strcmp(role, "function") == 0) {
+
+        const char *call_id =
+            cJSON_GetStringValue(
+                cJSON_GetObjectItemCaseSensitive(
+                    source, "tool_call_id"));
+
+        if (!call_id || !call_id[0]) {
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        char *result_text = message_text(source);
+
+        if (!result_text) {
+            result_text = strdup("");
+        }
+
+        if (!result_text) {
+            return ESP_ERR_NO_MEM;
+        }
+
+        cJSON *item = cJSON_CreateObject();
+
+        if (!item) {
+            free(result_text);
+            return ESP_ERR_NO_MEM;
+        }
+
+        cJSON_AddStringToObject(item, "type", "function_call_output");
+        cJSON_AddStringToObject(item, "call_id", call_id);
+        cJSON_AddStringToObject(item, "output", result_text);
+        cJSON_AddItemToArray(input, item);
+
+        free(result_text);
+        return ESP_OK;
+    }
+
+    char *text = message_text(source);
+
+    if (!text || !text[0]) {
+        free(text);
+        return ESP_OK;
+    }
+
+    const char *wire_role =
+        strcmp(role, "system") == 0 ? "developer" : role;
+
+    const char *part_type =
+        strcmp(role, "assistant") == 0
+            ? "output_text"
+            : "input_text";
+
+    cJSON *item = cJSON_CreateObject();
+    cJSON *content = cJSON_CreateArray();
+    cJSON *part = cJSON_CreateObject();
+
+    if (!item || !content || !part) {
+        cJSON_Delete(item);
+        cJSON_Delete(content);
+        cJSON_Delete(part);
+        free(text);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(item, "type", "message");
+    cJSON_AddStringToObject(item, "role", wire_role);
+    cJSON_AddStringToObject(part, "type", part_type);
+    cJSON_AddStringToObject(part, "text", text);
+    cJSON_AddItemToArray(content, part);
+    cJSON_AddItemToObject(item, "content", content);
+    cJSON_AddItemToArray(input, item);
+
+    free(text);
+    return ESP_OK;
+}
+
+
+static esp_err_t add_responses_tools(cJSON *body,
+                                     const char *tools_json,
+                                     bool *out_has_tools)
+{
+    if (!body || !out_has_tools) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *out_has_tools = false;
+
+    if (!tools_json || !tools_json[0]) {
+        return ESP_OK;
+    }
+
+    cJSON *source_tools = cJSON_Parse(tools_json);
+
+    if (!source_tools || !cJSON_IsArray(source_tools)) {
+        cJSON_Delete(source_tools);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    cJSON *wire_tools = cJSON_CreateArray();
+
+    if (!wire_tools) {
+        cJSON_Delete(source_tools);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON *source_tool = NULL;
+
+    cJSON_ArrayForEach(source_tool, source_tools) {
+        if (!cJSON_IsObject(source_tool)) {
+            cJSON_Delete(source_tools);
+            cJSON_Delete(wire_tools);
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        const char *type =
+            cJSON_GetStringValue(
+                cJSON_GetObjectItemCaseSensitive(
+                    source_tool, "type"));
+
+        if (!type || strcmp(type, "function") != 0) {
+            cJSON_Delete(source_tools);
+            cJSON_Delete(wire_tools);
+            return ESP_ERR_NOT_SUPPORTED;
+        }
+
+        cJSON *nested =
+            cJSON_GetObjectItemCaseSensitive(source_tool, "function");
+
+        cJSON *definition =
+            cJSON_IsObject(nested) ? nested : source_tool;
+
+        const char *name =
+            cJSON_GetStringValue(
+                cJSON_GetObjectItemCaseSensitive(definition, "name"));
+
+        const char *description =
+            cJSON_GetStringValue(
+                cJSON_GetObjectItemCaseSensitive(definition, "description"));
+
+        cJSON *parameters =
+            cJSON_GetObjectItemCaseSensitive(definition, "parameters");
+
+        if (!name || !name[0]) {
+            cJSON_Delete(source_tools);
+            cJSON_Delete(wire_tools);
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        cJSON *wire_tool = cJSON_CreateObject();
+
+        if (!wire_tool) {
+            cJSON_Delete(source_tools);
+            cJSON_Delete(wire_tools);
+            return ESP_ERR_NO_MEM;
+        }
+
+        cJSON_AddStringToObject(wire_tool, "type", "function");
+        cJSON_AddStringToObject(wire_tool, "name", name);
+
+        if (description && description[0]) {
+            cJSON_AddStringToObject(wire_tool, "description", description);
+        }
+
+        cJSON *parameters_copy =
+            parameters ? cJSON_Duplicate(parameters, true) : cJSON_CreateObject();
+
+        if (!parameters_copy) {
+            cJSON_Delete(wire_tool);
+            cJSON_Delete(source_tools);
+            cJSON_Delete(wire_tools);
+            return ESP_ERR_NO_MEM;
+        }
+
+        cJSON_AddItemToObject(wire_tool, "parameters", parameters_copy);
+
+        cJSON *strict =
+            cJSON_GetObjectItemCaseSensitive(definition, "strict");
+
+        if (strict) {
+            cJSON *strict_copy = cJSON_Duplicate(strict, true);
+
+            if (!strict_copy) {
+                cJSON_Delete(wire_tool);
+                cJSON_Delete(source_tools);
+                cJSON_Delete(wire_tools);
+                return ESP_ERR_NO_MEM;
+            }
+
+            cJSON_AddItemToObject(wire_tool, "strict", strict_copy);
+        }
+
+        cJSON_AddItemToArray(wire_tools, wire_tool);
+    }
+
+    cJSON_Delete(source_tools);
+
+    if (cJSON_GetArraySize(wire_tools) == 0) {
+        cJSON_Delete(wire_tools);
+        return ESP_OK;
+    }
+
+    cJSON_AddItemToObject(body, "tools", wire_tools);
+    *out_has_tools = true;
+    return ESP_OK;
+}
+
+
+
+static esp_err_t build_body(const openai_codex_backend_ctx_t *ctx,
+                            const claw_llm_chat_request_t *request,
+                            char **out_body,
+                            char **out_error_message)
+{
+    *out_body = NULL;
+
+    cJSON *body = cJSON_CreateObject();
+    cJSON *input = cJSON_CreateArray();
+
+    if (!body || !input) {
+        cJSON_Delete(body);
+        cJSON_Delete(input);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(body, "model", ctx->model);
+
+    if (request->system_prompt && request->system_prompt[0]) {
+        cJSON_AddStringToObject(body, "instructions", request->system_prompt);
+    }
+
+    if (request->messages && cJSON_IsArray(request->messages)) {
+        cJSON *message = NULL;
+
+        cJSON_ArrayForEach(message, request->messages) {
+            esp_err_t err = add_responses_message(input, message);
+
+            if (err != ESP_OK) {
+                cJSON_Delete(body);
+                cJSON_Delete(input);
+                *out_error_message = strdup("Failed building Codex input");
+                return err;
+            }
+        }
+    }
+
+    if (cJSON_GetArraySize(input) == 0) {
+        cJSON_Delete(body);
+        cJSON_Delete(input);
+        *out_error_message = strdup("Codex request has no input messages");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    bool has_tools = false;
+
+    esp_err_t tools_err =
+        add_responses_tools(body, request->tools_json, &has_tools);
+
+    if (tools_err != ESP_OK) {
+        cJSON_Delete(body);
+        cJSON_Delete(input);
+
+        *out_error_message =
+            strdup(tools_err == ESP_ERR_NOT_SUPPORTED
+                ? "Codex received unsupported tool type"
+                : "Invalid ESP-Claw tools JSON for Codex");
+
+        return tools_err;
+    }
+
+    cJSON_AddItemToObject(body, "input", input);
+    cJSON_AddStringToObject(body, "tool_choice", has_tools ? "auto" : "none");
+    cJSON_AddBoolToObject(body, "parallel_tool_calls", false);
+    cJSON_AddBoolToObject(body, "store", false);
+    cJSON_AddBoolToObject(body, "stream", true);
+
+    cJSON *include = cJSON_CreateArray();
+
+    if (!include) {
+        cJSON_Delete(body);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON *encrypted_reasoning =
+        cJSON_CreateString("reasoning.encrypted_content");
+
+    if (!encrypted_reasoning) {
+        cJSON_Delete(include);
+        cJSON_Delete(body);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddItemToArray(include, encrypted_reasoning);
+    cJSON_AddItemToObject(body, "include", include);
+
+    cJSON *reasoning = cJSON_CreateObject();
+
+    if (!reasoning) {
+        cJSON_Delete(body);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(reasoning, "effort", "low");
+    cJSON_AddStringToObject(reasoning, "summary", "auto");
+    cJSON_AddItemToObject(body, "reasoning", reasoning);
+
+    *out_body = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+
+    return *out_body ? ESP_OK : ESP_ERR_NO_MEM;
+}
+
+
+static esp_err_t output_item_text(cJSON *event, char **fallback, size_t *fallback_len)
+{
+    cJSON *item = cJSON_GetObjectItemCaseSensitive(event, "item");
+    if (!cJSON_IsObject(item)) return ESP_OK;
+    const char *type = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(item, "type"));
+    const char *role = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(item, "role"));
+    if (!type || strcmp(type,"message") != 0 || !role || strcmp(role,"assistant") != 0) return ESP_OK;
+    cJSON *content = cJSON_GetObjectItemCaseSensitive(item, "content");
+    if (!cJSON_IsArray(content)) return ESP_OK;
+    cJSON *part = NULL;
+    cJSON_ArrayForEach(part, content) {
+        const char *pt = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(part,"type"));
+        const char *tx = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(part,"text"));
+        if (pt && strcmp(pt,"output_text") == 0 && tx) {
+            esp_err_t err = append_text(fallback,fallback_len,tx);
+            if (err != ESP_OK) return err;
+        }
+    }
+    return ESP_OK;
+}
+
+
+static void codex_clear_tool_calls(claw_llm_response_t *response)
+{
+    if (!response) return;
+
+    for (size_t i = 0; i < response->tool_call_count; i++) {
+        free(response->tool_calls[i].id);
+        free(response->tool_calls[i].name);
+        free(response->tool_calls[i].arguments_json);
+    }
+
+    free(response->tool_calls);
+    response->tool_calls = NULL;
+    response->tool_call_count = 0;
+}
+
+
+static esp_err_t codex_append_tool_call(claw_llm_response_t *response,
+                                        cJSON *item)
+{
+    if (!response || !item || !cJSON_IsObject(item)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const char *call_id =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(item, "call_id"));
+    const char *name =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(item, "name"));
+    const char *arguments =
+        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(item, "arguments"));
+
+    if (!call_id || !call_id[0] ||
+        !name || !name[0] ||
+        !arguments) {
+        return ESP_FAIL;
+    }
+
+    size_t old_count = response->tool_call_count;
+
+    claw_llm_tool_call_t *grown =
+        realloc(response->tool_calls,
+                (old_count + 1U) * sizeof(claw_llm_tool_call_t));
+
+    if (!grown) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    response->tool_calls = grown;
+
+    claw_llm_tool_call_t *dst =
+        &response->tool_calls[old_count];
+
+    memset(dst, 0, sizeof(*dst));
+
+    dst->id = strdup(call_id);
+    dst->name = strdup(name);
+    dst->arguments_json = strdup(arguments);
+
+    if (!dst->id || !dst->name || !dst->arguments_json) {
+        free(dst->id);
+        free(dst->name);
+        free(dst->arguments_json);
+        memset(dst, 0, sizeof(*dst));
+        return ESP_ERR_NO_MEM;
+    }
+
+    response->tool_call_count = old_count + 1U;
+    return ESP_OK;
+}
+
+
+static esp_err_t parse_sse(const char *body,
+                           claw_llm_response_t *out_response,
+                           char **out_error_message)
+{
+    memset(out_response, 0, sizeof(*out_response));
+
+    char *copy = strdup(body ? body : "");
+    if (!copy) return ESP_ERR_NO_MEM;
+
+    cJSON *output_items = cJSON_CreateArray();
+
+    if (!output_items) {
+        free(copy);
+        return ESP_ERR_NO_MEM;
+    }
+
+    char *text = NULL;
+    char *fallback = NULL;
+    size_t text_len = 0;
+    size_t fallback_len = 0;
+    bool completed = false;
+    esp_err_t err = ESP_OK;
+    char *saveptr = NULL;
+
+    for (char *line = strtok_r(copy, "\n", &saveptr);
+         line;
+         line = strtok_r(NULL, "\n", &saveptr)) {
+
+        size_t n = strlen(line);
+
+        if (n && line[n - 1] == '\r') {
+            line[n - 1] = '\0';
+        }
+
+        if (strncmp(line, "data:", 5) != 0) continue;
+
+        const char *payload = line + 5;
+
+        while (*payload == ' ' || *payload == '\t') {
+            payload++;
+        }
+
+        if (!payload[0] || strcmp(payload, "[DONE]") == 0) continue;
+
+        cJSON *event = cJSON_Parse(payload);
+        if (!event) continue;
+
+        const char *type =
+            cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(event, "type"));
+
+        if (type && strcmp(type, "response.output_text.delta") == 0) {
+            const char *delta =
+                cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(event, "delta"));
+
+            if (delta) {
+                err = append_text(&text, &text_len, delta);
+            }
+
+        } else if (type && strcmp(type, "response.output_item.done") == 0) {
+            cJSON *item =
+                cJSON_GetObjectItemCaseSensitive(event, "item");
+
+            if (cJSON_IsObject(item)) {
+                cJSON *saved = cJSON_Duplicate(item, true);
+
+                if (!saved) {
+                    err = ESP_ERR_NO_MEM;
+                } else {
+                    cJSON_AddItemToArray(output_items, saved);
+                }
+
+                if (err == ESP_OK) {
+                    const char *item_type =
+                        cJSON_GetStringValue(
+                            cJSON_GetObjectItemCaseSensitive(item, "type"));
+
+                    if (item_type && strcmp(item_type, "function_call") == 0) {
+                        err = codex_append_tool_call(out_response, item);
+                    } else {
+                        err = output_item_text(event, &fallback, &fallback_len);
+                    }
+                }
+            }
+
+        } else if (type && strcmp(type, "response.completed") == 0) {
+            completed = true;
+
+        } else if (type && strcmp(type, "response.failed") == 0) {
+            cJSON *response =
+                cJSON_GetObjectItemCaseSensitive(event, "response");
+
+            cJSON *error_obj =
+                cJSON_IsObject(response)
+                    ? cJSON_GetObjectItemCaseSensitive(response, "error")
+                    : NULL;
+
+            const char *message =
+                cJSON_IsObject(error_obj)
+                    ? cJSON_GetStringValue(
+                          cJSON_GetObjectItemCaseSensitive(error_obj, "message"))
+                    : NULL;
+
+            *out_error_message =
+                dup_printf("Codex response.failed%s%s",
+                           message ? ": " : "",
+                           message ? message : "");
+
+            err = ESP_FAIL;
+        }
+
+        cJSON_Delete(event);
+
+        if (err != ESP_OK) break;
+    }
+
+    free(copy);
+
+    if (err != ESP_OK) {
+        free(text);
+        free(fallback);
+        cJSON_Delete(output_items);
+        codex_clear_tool_calls(out_response);
+
+        if (!*out_error_message) {
+            *out_error_message =
+                strdup(err == ESP_ERR_NO_MEM
+                    ? "Out of memory parsing Codex response"
+                    : "Malformed Codex function_call response");
+        }
+
+        return err;
+    }
+
+    if (!completed) {
+        free(text);
+        free(fallback);
+        cJSON_Delete(output_items);
+        codex_clear_tool_calls(out_response);
+
+        *out_error_message =
+            strdup("Codex SSE stream ended before response.completed");
+
+        return ESP_FAIL;
+    }
+
+    if (!text || !text[0]) {
+        free(text);
+        text = fallback;
+        fallback = NULL;
+    }
+
+    free(fallback);
+
+    if ((!text || !text[0]) && out_response->tool_call_count == 0) {
+        free(text);
+        cJSON_Delete(output_items);
+
+        *out_error_message =
+            strdup("Codex returned no assistant text or tool call");
+
+        return ESP_FAIL;
+    }
+
+    out_response->text = text;
+
+    cJSON *raw = cJSON_CreateObject();
+
+    if (!raw) {
+        free(out_response->text);
+        out_response->text = NULL;
+        cJSON_Delete(output_items);
+        codex_clear_tool_calls(out_response);
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(raw, "role", "assistant");
+
+    if (out_response->tool_call_count > 0) {
+        if (out_response->text && out_response->text[0]) {
+            cJSON_AddStringToObject(raw, "content", out_response->text);
+        }
+
+        cJSON_AddItemToObject(raw, "_codex_output", output_items);
+        output_items = NULL;
+
+    } else {
+        cJSON_Delete(output_items);
+        output_items = NULL;
+
+        cJSON_AddStringToObject(
+            raw,
+            "content",
+            out_response->text ? out_response->text : "");
+    }
+
+    out_response->raw_message_json =
+        cJSON_PrintUnformatted(raw);
+
+    cJSON_Delete(raw);
+
+    if (!out_response->raw_message_json) {
+        free(out_response->text);
+        out_response->text = NULL;
+        codex_clear_tool_calls(out_response);
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+
+
+static esp_err_t openai_codex_init(const claw_llm_runtime_config_t *config,
+                                   const claw_llm_model_profile_t *profile,
+                                   void **out_backend_ctx,
+                                   char **out_error_message)
+{
+    (void)profile;
+    if (!config || !out_backend_ctx || !out_error_message) return ESP_ERR_INVALID_ARG;
+    *out_error_message = NULL;
+    if (!config->model || !config->model[0]) {
+        *out_error_message = strdup("OpenAI Codex model is not configured");
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (strlcpy(s_ctx.model,config->model,sizeof(s_ctx.model)) >= sizeof(s_ctx.model)) {
+        *out_error_message = strdup("OpenAI Codex model name is too long");
+        return ESP_ERR_INVALID_SIZE;
+    }
+    s_ctx.timeout_ms = config->timeout_ms ? config->timeout_ms : OPENAI_CODEX_DEFAULT_TIMEOUT_MS;
+    *out_backend_ctx = &s_ctx;
+    return ESP_OK;
+}
+
+static esp_err_t openai_codex_chat(void *backend_ctx,
+                                   const claw_llm_model_profile_t *profile,
+                                   const claw_llm_chat_request_t *request,
+                                   claw_llm_response_t *out_response,
+                                   char **out_error_message)
+{
+    (void)profile;
+    if (!backend_ctx || !request || !out_response || !out_error_message) return ESP_ERR_INVALID_ARG;
+    *out_error_message = NULL;
+    memset(out_response,0,sizeof(*out_response));
+
+    openai_codex_backend_ctx_t *ctx = (openai_codex_backend_ctx_t *)backend_ctx;
+    char *access_token = NULL, *account_id = NULL, *post_data = NULL, *transport_error = NULL;
+    claw_llm_http_response_t http_response = {0};
+
+    esp_err_t err = claw_openai_codex_auth_get_session(&access_token,&account_id);
+    if (err != ESP_OK) {
+        *out_error_message = strdup("ChatGPT OAuth session is not connected");
+        goto cleanup;
+    }
+    err = build_body(ctx,request,&post_data,out_error_message);
+    if (err != ESP_OK) goto cleanup;
+
+    const claw_llm_http_header_t headers[] = {
+        {"ChatGPT-Account-ID",account_id},
+        {"Accept","text/event-stream"},
+        {"originator",OPENAI_CODEX_ORIGINATOR},
+        {"User-Agent",OPENAI_CODEX_USER_AGENT},
+    };
+
+    claw_llm_http_json_request_t http_request = {0};
+    http_request.url = OPENAI_CODEX_RESPONSES_URL;
+    http_request.body = post_data;
+    http_request.api_key = access_token;
+    http_request.auth_type = "bearer";
+    http_request.timeout_ms = ctx->timeout_ms;
+    http_request.abort_flag = request->abort_flag;
+    http_request.headers = headers;
+    http_request.header_count = sizeof(headers)/sizeof(headers[0]);
+    http_request.content_type = "application/json";
+    http_request.accept_non_200 = true;
+
+    err = claw_llm_http_post_json(&http_request,&http_response,&transport_error);
+    if (err != ESP_OK) {
+        *out_error_message = transport_error ? transport_error : strdup("Codex HTTP transport failed");
+        transport_error = NULL;
+        goto cleanup;
+    }
+    if (http_response.status_code < 200 || http_response.status_code >= 300) {
+        *out_error_message = dup_printf("Codex HTTP %d: %.320s",http_response.status_code,
+                                        http_response.body ? http_response.body : "(empty response)");
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+    err = parse_sse(http_response.body ? http_response.body : "",out_response,out_error_message);
+
+cleanup:
+    free(access_token); free(account_id); free(post_data); free(transport_error);
+    claw_llm_http_response_free(&http_response);
+    return err;
+}
+
+static esp_err_t openai_codex_infer_media(void *backend_ctx,
+                                          const claw_llm_model_profile_t *profile,
+                                          const claw_llm_media_request_t *request,
+                                          char **out_text,
+                                          char **out_error_message)
+{
+    (void)backend_ctx;
+    if (!profile || !request || !out_text || !out_error_message) return ESP_ERR_INVALID_ARG;
+    *out_text = NULL;
+    *out_error_message = strdup("OpenAI Codex media inference is not implemented yet");
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+static const claw_llm_backend_vtable_t s_openai_codex_vtable = {
+    .id = CLAW_LLM_BACKEND_OPENAI_CODEX_ID,
+    .init = openai_codex_init,
+    .chat = openai_codex_chat,
+    .infer_media = openai_codex_infer_media,
+};
+
+static const claw_llm_backend_registration_t s_openai_codex_registration = {
+    .id = CLAW_LLM_BACKEND_OPENAI_CODEX_ID,
+    .vtable = &s_openai_codex_vtable,
+    .defaults = {
+        .auth_type = CLAW_LLM_BACKEND_OPENAI_CODEX_AUTH_TYPE,
+        .chat_path = CLAW_LLM_BACKEND_OPENAI_CODEX_CHAT_PATH,
+        .max_tokens_field = CLAW_LLM_BACKEND_OPENAI_CODEX_DEFAULT_MAX_TOKENS_FIELD,
+    },
+};
+
+const claw_llm_backend_vtable_t *claw_llm_backend_openai_codex_vtable(void)
+{
+    return &s_openai_codex_vtable;
+}
+
+const claw_llm_backend_registration_t *claw_llm_backend_openai_codex_registration(void)
+{
+    return &s_openai_codex_registration;
+}

--- a/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_openai_codex.h
+++ b/components/claw_modules/claw_core/src/llm/backends/claw_llm_backend_openai_codex.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "llm/claw_llm_runtime.h"
+
+#define CLAW_LLM_BACKEND_OPENAI_CODEX_ID "openai_codex"
+#define CLAW_LLM_BACKEND_OPENAI_CODEX_CHAT_PATH "/responses"
+#define CLAW_LLM_BACKEND_OPENAI_CODEX_AUTH_TYPE "bearer"
+#define CLAW_LLM_BACKEND_OPENAI_CODEX_DEFAULT_MAX_TOKENS_FIELD "max_output_tokens"
+
+const claw_llm_backend_vtable_t *claw_llm_backend_openai_codex_vtable(void);
+const claw_llm_backend_registration_t *claw_llm_backend_openai_codex_registration(void);

--- a/components/claw_modules/claw_core/src/llm/claw_llm_http_transport.c
+++ b/components/claw_modules/claw_core/src/llm/claw_llm_http_transport.c
@@ -316,7 +316,12 @@ esp_err_t claw_llm_http_post_json(const claw_llm_http_json_request_t *request,
     }
 
     esp_http_client_set_method(client, HTTP_METHOD_POST);
-    esp_http_client_set_header(client, "Content-Type", "application/json");
+    esp_http_client_set_header(
+        client,
+        "Content-Type",
+        (request->content_type && request->content_type[0])
+            ? request->content_type
+            : "application/json");
     auth_header_value = build_auth_header_value(request->auth_type, request->api_key);
     if (auth_header_value) {
         esp_http_client_set_header(client, auth_header_name(request->auth_type), auth_header_value);
@@ -357,7 +362,7 @@ esp_err_t claw_llm_http_post_json(const claw_llm_http_json_request_t *request,
 
     status_code = esp_http_client_get_status_code(client);
     ESP_LOGD(TAG, "HTTP status=%d", status_code);
-    if (status_code != 200) {
+    if (status_code != 200 && !request->accept_non_200) {
         err = ESP_FAIL;
         *out_error_message = parse_error_message_body(buffer.data, status_code);
         ESP_LOGE(TAG, "LLM error: %s", *out_error_message ? *out_error_message : "(null)");

--- a/components/claw_modules/claw_core/src/llm/claw_llm_types.h
+++ b/components/claw_modules/claw_core/src/llm/claw_llm_types.h
@@ -104,6 +104,8 @@ typedef struct {
     volatile bool *abort_flag;
     const claw_llm_http_header_t *headers;
     size_t header_count;
+    const char *content_type;
+    bool accept_non_200;
 } claw_llm_http_json_request_t;
 
 typedef struct {

--- a/components/claw_modules/claw_core/src/llm/claw_openai_codex_auth.c
+++ b/components/claw_modules/claw_core/src/llm/claw_openai_codex_auth.c
@@ -1,0 +1,1394 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "claw_openai_codex_auth.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "cJSON.h"
+#include "esp_log.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#include "llm/claw_llm_http_transport.h"
+#include "llm/claw_openai_codex_store.h"
+#include "mbedtls/base64.h"
+
+#define OPENAI_CODEX_CLIENT_ID \
+    "app_EMoamEEZ73f0CkXaXp7hrann"
+
+#define OPENAI_CODEX_DEVICE_CODE_URL \
+    "https://auth.openai.com/api/accounts/deviceauth/usercode"
+
+#define OPENAI_CODEX_DEVICE_TOKEN_URL \
+    "https://auth.openai.com/api/accounts/deviceauth/token"
+
+#define OPENAI_CODEX_TOKEN_URL \
+    "https://auth.openai.com/oauth/token"
+
+#define OPENAI_CODEX_VERIFICATION_URL \
+    "https://auth.openai.com/codex/device"
+
+#define OPENAI_CODEX_REDIRECT_URI \
+    "https://auth.openai.com/deviceauth/callback"
+
+#define OPENAI_CODEX_HTTP_TIMEOUT_MS 20000
+#define OPENAI_CODEX_MAX_LOGIN_SECONDS (15 * 60)
+#define OPENAI_CODEX_DEFAULT_INTERVAL 5
+#define OPENAI_CODEX_POLL_TASK_STACK 8192
+#define OPENAI_CODEX_POLL_TASK_PRIORITY 5
+
+typedef struct {
+    bool active;
+    bool completed;
+
+    char status[32];
+    char message[160];
+
+    char user_code[32];
+    char verification_url[160];
+
+    uint32_t interval;
+} openai_codex_login_state_t;
+
+typedef struct {
+    char device_auth_id[256];
+    char user_code[32];
+    uint32_t interval;
+} openai_codex_poll_args_t;
+
+static const char *TAG = "openai_codex_auth";
+
+static openai_codex_login_state_t s_login;
+
+static SemaphoreHandle_t s_state_lock;
+static bool s_worker_running;
+static volatile bool s_cancel_requested;
+
+/*
+ * Tokens stay in RAM in this stage.
+ * Persistent refresh-token storage will be added after this login path
+ * has been verified end-to-end.
+ */
+static char *s_id_token;
+static char *s_access_token;
+static char *s_refresh_token;
+
+
+static esp_err_t ensure_state_lock(void)
+{
+    if (s_state_lock) {
+        return ESP_OK;
+    }
+
+    s_state_lock = xSemaphoreCreateMutex();
+
+    if (!s_state_lock) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+
+
+static void state_lock(void)
+{
+    if (s_state_lock) {
+        xSemaphoreTake(s_state_lock, portMAX_DELAY);
+    }
+}
+
+
+static void state_unlock(void)
+{
+    if (s_state_lock) {
+        xSemaphoreGive(s_state_lock);
+    }
+}
+
+
+static void state_set_error(const char *message)
+{
+    state_lock();
+
+    s_login.active = false;
+    s_login.completed = false;
+
+    strlcpy(s_login.status,
+            "error",
+            sizeof(s_login.status));
+
+    strlcpy(s_login.message,
+            message ? message : "OpenAI login error",
+            sizeof(s_login.message));
+
+    state_unlock();
+}
+
+
+static void worker_finished(void)
+{
+    state_lock();
+    s_worker_running = false;
+    state_unlock();
+}
+
+
+static char *string_printf(const char *fmt, ...)
+{
+    va_list args;
+    va_list copy;
+    int needed;
+    char *buf;
+
+    va_start(args, fmt);
+    va_copy(copy, args);
+
+    needed = vsnprintf(NULL, 0, fmt, copy);
+
+    va_end(copy);
+
+    if (needed < 0) {
+        va_end(args);
+        return NULL;
+    }
+
+    buf = calloc(1, (size_t)needed + 1);
+
+    if (!buf) {
+        va_end(args);
+        return NULL;
+    }
+
+    vsnprintf(buf, (size_t)needed + 1, fmt, args);
+
+    va_end(args);
+
+    return buf;
+}
+
+
+static bool url_unreserved(unsigned char c)
+{
+    return isalnum(c) ||
+           c == '-' ||
+           c == '.' ||
+           c == '_' ||
+           c == '~';
+}
+
+
+static char *form_url_encode(const char *src)
+{
+    static const char hex[] = "0123456789ABCDEF";
+
+    size_t src_len;
+    size_t out_len = 0;
+    char *out;
+    char *dst;
+
+    if (!src) {
+        return NULL;
+    }
+
+    src_len = strlen(src);
+
+    for (size_t i = 0; i < src_len; ++i) {
+        unsigned char c = (unsigned char)src[i];
+
+        out_len += url_unreserved(c) ? 1 : 3;
+    }
+
+    out = calloc(1, out_len + 1);
+
+    if (!out) {
+        return NULL;
+    }
+
+    dst = out;
+
+    for (size_t i = 0; i < src_len; ++i) {
+        unsigned char c = (unsigned char)src[i];
+
+        if (url_unreserved(c)) {
+            *dst++ = (char)c;
+        } else {
+            *dst++ = '%';
+            *dst++ = hex[(c >> 4) & 0x0F];
+            *dst++ = hex[c & 0x0F];
+        }
+    }
+
+    *dst = '\0';
+
+    return out;
+}
+
+
+static uint32_t parse_interval(cJSON *item)
+{
+    if (cJSON_IsNumber(item) && item->valuedouble > 0) {
+        return (uint32_t)item->valuedouble;
+    }
+
+    if (cJSON_IsString(item) &&
+            item->valuestring &&
+            item->valuestring[0]) {
+
+        char *end = NULL;
+
+        unsigned long value =
+            strtoul(item->valuestring, &end, 10);
+
+        if (end &&
+                *end == '\0' &&
+                value > 0 &&
+                value <= 300) {
+            return (uint32_t)value;
+        }
+    }
+
+    return OPENAI_CODEX_DEFAULT_INTERVAL;
+}
+
+
+static char *extract_chatgpt_account_id(const char *jwt)
+{
+    if (!jwt || !jwt[0]) return NULL;
+
+    const char *dot1 = strchr(jwt, '.');
+    if (!dot1) return NULL;
+    const char *payload = dot1 + 1;
+    const char *dot2 = strchr(payload, '.');
+    if (!dot2 || dot2 == payload) return NULL;
+
+    size_t payload_len = (size_t)(dot2 - payload);
+    size_t padded_len = (payload_len + 3U) & ~3U;
+    char *encoded = calloc(1, padded_len + 1U);
+    if (!encoded) return NULL;
+
+    for (size_t i = 0; i < payload_len; ++i) {
+        char c = payload[i];
+        encoded[i] = (c == '-') ? '+' : ((c == '_') ? '/' : c);
+    }
+    for (size_t i = payload_len; i < padded_len; ++i) encoded[i] = '=';
+
+    size_t decoded_cap = (padded_len / 4U) * 3U + 1U;
+    unsigned char *decoded = calloc(1, decoded_cap);
+    if (!decoded) { free(encoded); return NULL; }
+
+    size_t decoded_len = 0;
+    int rc = mbedtls_base64_decode(decoded, decoded_cap - 1U, &decoded_len,
+                                   (const unsigned char *)encoded, padded_len);
+    free(encoded);
+    if (rc != 0) { free(decoded); return NULL; }
+    decoded[decoded_len] = '\0';
+
+    cJSON *root = cJSON_Parse((const char *)decoded);
+    free(decoded);
+    if (!root) return NULL;
+
+    cJSON *auth = cJSON_GetObjectItemCaseSensitive(root, "https://api.openai.com/auth");
+    const char *account_id = NULL;
+    if (cJSON_IsObject(auth)) {
+        account_id = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(auth, "chatgpt_account_id"));
+    }
+    char *result = (account_id && account_id[0]) ? strdup(account_id) : NULL;
+    cJSON_Delete(root);
+    return result;
+}
+static esp_err_t exchange_authorization_code(
+    const char *authorization_code,
+    const char *code_verifier)
+{
+    char *encoded_code = NULL;
+    char *encoded_redirect = NULL;
+    char *encoded_client = NULL;
+    char *encoded_verifier = NULL;
+    char *body = NULL;
+
+    claw_llm_http_json_request_t request = {0};
+    claw_llm_http_response_t response = {0};
+
+    char *transport_error = NULL;
+
+    cJSON *root = NULL;
+
+    const char *id_token_value;
+    const char *access_token_value;
+    const char *refresh_token_value;
+
+    char *new_id_token = NULL;
+    char *new_access_token = NULL;
+    char *new_refresh_token = NULL;
+
+    esp_err_t err = ESP_FAIL;
+
+    encoded_code =
+        form_url_encode(authorization_code);
+
+    encoded_redirect =
+        form_url_encode(OPENAI_CODEX_REDIRECT_URI);
+
+    encoded_client =
+        form_url_encode(OPENAI_CODEX_CLIENT_ID);
+
+    encoded_verifier =
+        form_url_encode(code_verifier);
+
+    if (!encoded_code ||
+            !encoded_redirect ||
+            !encoded_client ||
+            !encoded_verifier) {
+        err = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    body = string_printf(
+        "grant_type=authorization_code"
+        "&code=%s"
+        "&redirect_uri=%s"
+        "&client_id=%s"
+        "&code_verifier=%s",
+        encoded_code,
+        encoded_redirect,
+        encoded_client,
+        encoded_verifier);
+
+    if (!body) {
+        err = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    request.url = OPENAI_CODEX_TOKEN_URL;
+    request.body = body;
+    request.content_type =
+        "application/x-www-form-urlencoded";
+    request.accept_non_200 = true;
+    request.timeout_ms =
+        OPENAI_CODEX_HTTP_TIMEOUT_MS;
+
+    err = claw_llm_http_post_json(
+        &request,
+        &response,
+        &transport_error);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "OAuth token request failed: %s",
+                 transport_error
+                    ? transport_error
+                    : esp_err_to_name(err));
+
+        goto cleanup;
+    }
+
+    if (response.status_code < 200 ||
+            response.status_code >= 300) {
+
+        ESP_LOGE(TAG,
+                 "OAuth token endpoint returned HTTP %d",
+                 response.status_code);
+
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+
+    if (!response.body || !response.body[0]) {
+        ESP_LOGE(TAG,
+                 "OAuth token endpoint returned empty body");
+
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+
+    root = cJSON_Parse(response.body);
+
+    if (!root) {
+        ESP_LOGE(TAG,
+                 "Could not parse OAuth token response");
+
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+
+    id_token_value =
+        cJSON_GetStringValue(
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "id_token"));
+
+    access_token_value =
+        cJSON_GetStringValue(
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "access_token"));
+
+    refresh_token_value =
+        cJSON_GetStringValue(
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "refresh_token"));
+
+    if (!id_token_value ||
+            !id_token_value[0] ||
+            !access_token_value ||
+            !access_token_value[0] ||
+            !refresh_token_value ||
+            !refresh_token_value[0]) {
+
+        ESP_LOGE(TAG,
+                 "OAuth token response is incomplete");
+
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+
+    new_id_token =
+        strdup(id_token_value);
+
+    new_access_token =
+        strdup(access_token_value);
+
+    new_refresh_token =
+        strdup(refresh_token_value);
+
+    if (!new_id_token ||
+            !new_access_token ||
+            !new_refresh_token) {
+
+        err = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    /* Persist only the durable credential. Access and ID tokens remain RAM-only. */
+    err = claw_openai_codex_store_save_refresh_token(new_refresh_token);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "Could not persist ChatGPT refresh token: %s",
+                 esp_err_to_name(err));
+        goto cleanup;
+    }
+
+    {
+        char *account_id = extract_chatgpt_account_id(new_id_token);
+        if (!account_id) account_id = extract_chatgpt_account_id(new_access_token);
+        if (!account_id) {
+            ESP_LOGE(TAG, "ChatGPT token does not contain chatgpt_account_id");
+            err = ESP_FAIL;
+            goto cleanup;
+        }
+        err = claw_openai_codex_store_save_account_id(account_id);
+        free(account_id);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Could not persist ChatGPT account id: %s", esp_err_to_name(err));
+            goto cleanup;
+        }
+    }
+    /*
+     * Swap credentials only after the complete response has
+     * successfully been parsed.
+     */
+    state_lock();
+
+    free(s_id_token);
+    free(s_access_token);
+    free(s_refresh_token);
+
+    s_id_token = new_id_token;
+    s_access_token = new_access_token;
+    s_refresh_token = new_refresh_token;
+
+    new_id_token = NULL;
+    new_access_token = NULL;
+    new_refresh_token = NULL;
+
+    s_login.active = false;
+    s_login.completed = true;
+    s_login.user_code[0] = '\0';
+    s_login.verification_url[0] = '\0';
+    s_login.interval = 0;
+
+    strlcpy(s_login.status,
+            "connected",
+            sizeof(s_login.status));
+
+    strlcpy(s_login.message,
+            "ChatGPT connected",
+            sizeof(s_login.message));
+
+    state_unlock();
+
+    ESP_LOGI(TAG,
+             "ChatGPT OAuth login completed successfully");
+
+    err = ESP_OK;
+
+cleanup:
+    free(encoded_code);
+    free(encoded_redirect);
+    free(encoded_client);
+    free(encoded_verifier);
+    free(body);
+
+    free(new_id_token);
+    free(new_access_token);
+    free(new_refresh_token);
+
+    free(transport_error);
+
+    if (root) {
+        cJSON_Delete(root);
+    }
+
+    claw_llm_http_response_free(&response);
+
+    return err;
+}
+
+
+static esp_err_t refresh_chatgpt_session(const char *stored_refresh_token)
+{
+    if (!stored_refresh_token || !stored_refresh_token[0]) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    cJSON *request_json = cJSON_CreateObject();
+    if (!request_json) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    cJSON_AddStringToObject(request_json, "client_id", OPENAI_CODEX_CLIENT_ID);
+    cJSON_AddStringToObject(request_json, "grant_type", "refresh_token");
+    cJSON_AddStringToObject(request_json, "refresh_token", stored_refresh_token);
+
+    char *request_body = cJSON_PrintUnformatted(request_json);
+    cJSON_Delete(request_json);
+    if (!request_body) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    claw_llm_http_json_request_t request = {0};
+    claw_llm_http_response_t response = {0};
+    char *transport_error = NULL;
+
+    request.url = OPENAI_CODEX_TOKEN_URL;
+    request.body = request_body;
+    request.content_type = "application/json";
+    request.accept_non_200 = true;
+    request.timeout_ms = OPENAI_CODEX_HTTP_TIMEOUT_MS;
+
+    esp_err_t err = claw_llm_http_post_json(&request, &response, &transport_error);
+    free(request_body);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "ChatGPT refresh transport failed: %s",
+                 transport_error ? transport_error : esp_err_to_name(err));
+        free(transport_error);
+        claw_llm_http_response_free(&response);
+        return err;
+    }
+    free(transport_error);
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        ESP_LOGE(TAG, "ChatGPT refresh returned HTTP %d", response.status_code);
+        claw_llm_http_response_free(&response);
+        return ESP_FAIL;
+    }
+
+    cJSON *root = cJSON_Parse(response.body ? response.body : "");
+    if (!root) {
+        claw_llm_http_response_free(&response);
+        return ESP_FAIL;
+    }
+
+    const char *access_value = cJSON_GetStringValue(
+        cJSON_GetObjectItemCaseSensitive(root, "access_token"));
+    const char *id_value = cJSON_GetStringValue(
+        cJSON_GetObjectItemCaseSensitive(root, "id_token"));
+    const char *refresh_value = cJSON_GetStringValue(
+        cJSON_GetObjectItemCaseSensitive(root, "refresh_token"));
+
+    if (!access_value || !access_value[0]) {
+        cJSON_Delete(root);
+        claw_llm_http_response_free(&response);
+        ESP_LOGE(TAG, "ChatGPT refresh response has no access_token");
+        return ESP_FAIL;
+    }
+
+    char *new_access = strdup(access_value);
+    char *new_id = (id_value && id_value[0]) ? strdup(id_value) : NULL;
+    char *new_refresh = (refresh_value && refresh_value[0])
+        ? strdup(refresh_value)
+        : strdup(stored_refresh_token);
+
+    if (!new_access || !new_refresh || ((id_value && id_value[0]) && !new_id)) {
+        free(new_access);
+        free(new_id);
+        free(new_refresh);
+        cJSON_Delete(root);
+        claw_llm_http_response_free(&response);
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (refresh_value && refresh_value[0] &&
+            strcmp(refresh_value, stored_refresh_token) != 0) {
+        err = claw_openai_codex_store_save_refresh_token(new_refresh);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG,
+                     "Could not persist rotated refresh token: %s",
+                     esp_err_to_name(err));
+            free(new_access);
+            free(new_id);
+            free(new_refresh);
+            cJSON_Delete(root);
+            claw_llm_http_response_free(&response);
+            return err;
+        }
+    }
+    {
+        char *account_id = new_id ? extract_chatgpt_account_id(new_id) : NULL;
+        if (!account_id) account_id = extract_chatgpt_account_id(new_access);
+        if (account_id) {
+            esp_err_t account_err = claw_openai_codex_store_save_account_id(account_id);
+            if (account_err != ESP_OK) {
+                ESP_LOGW(TAG, "Could not update ChatGPT account id: %s", esp_err_to_name(account_err));
+            }
+            free(account_id);
+        }
+    }
+
+    state_lock();
+    free(s_access_token);
+    free(s_id_token);
+    free(s_refresh_token);
+    s_access_token = new_access;
+    s_id_token = new_id;
+    s_refresh_token = new_refresh;
+    s_login.active = false;
+    s_login.completed = true;
+    s_login.user_code[0] = '\0';
+    s_login.verification_url[0] = '\0';
+    strlcpy(s_login.status, "connected", sizeof(s_login.status));
+    strlcpy(s_login.message, "ChatGPT connected", sizeof(s_login.message));
+    state_unlock();
+
+    cJSON_Delete(root);
+    claw_llm_http_response_free(&response);
+    ESP_LOGI(TAG, "ChatGPT session restored from refresh token");
+    return ESP_OK;
+}
+
+static void openai_codex_restore_task(void *arg)
+{
+    char *refresh_token = (char *)arg;
+    esp_err_t err = refresh_chatgpt_session(refresh_token);
+    free(refresh_token);
+
+    if (err != ESP_OK) {
+        state_set_error("Stored ChatGPT login could not be refreshed");
+    }
+
+    worker_finished();
+    vTaskDelete(NULL);
+}
+
+esp_err_t claw_openai_codex_auth_restore_async(void)
+{
+    esp_err_t err = ensure_state_lock();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    state_lock();
+    if (s_worker_running || s_login.completed) {
+        state_unlock();
+        return ESP_OK;
+    }
+    state_unlock();
+
+    char *refresh_token = NULL;
+    err = claw_openai_codex_store_load_refresh_token(&refresh_token);
+
+    if (err == ESP_ERR_NOT_FOUND) {
+        state_lock();
+        if (!s_login.status[0]) {
+            strlcpy(s_login.status, "disconnected", sizeof(s_login.status));
+            strlcpy(s_login.message, "ChatGPT not connected", sizeof(s_login.message));
+        }
+        state_unlock();
+        return ESP_OK;
+    }
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    state_lock();
+    if (s_worker_running || s_login.completed) {
+        state_unlock();
+        free(refresh_token);
+        return ESP_OK;
+    }
+
+    s_cancel_requested = false;
+    s_worker_running = true;
+    s_login.active = true;
+    s_login.completed = false;
+    strlcpy(s_login.status, "refreshing", sizeof(s_login.status));
+    strlcpy(s_login.message, "Restoring ChatGPT login", sizeof(s_login.message));
+    state_unlock();
+
+    BaseType_t task_ok = xTaskCreate(
+        openai_codex_restore_task,
+        "codex_restore",
+        OPENAI_CODEX_POLL_TASK_STACK,
+        refresh_token,
+        OPENAI_CODEX_POLL_TASK_PRIORITY,
+        NULL);
+
+    if (task_ok != pdPASS) {
+        state_lock();
+        s_worker_running = false;
+        state_unlock();
+        free(refresh_token);
+        state_set_error("Could not start ChatGPT restore task");
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+
+static void openai_codex_poll_task(void *arg)
+{
+    openai_codex_poll_args_t *poll =
+        (openai_codex_poll_args_t *)arg;
+
+    TickType_t start_tick =
+        xTaskGetTickCount();
+
+    if (!poll) {
+        state_set_error(
+            "OpenAI polling task has no context");
+
+        worker_finished();
+        vTaskDelete(NULL);
+        return;
+    }
+
+    while (!s_cancel_requested) {
+        cJSON *request_json = NULL;
+        char *request_body = NULL;
+
+        claw_llm_http_json_request_t request = {0};
+        claw_llm_http_response_t response = {0};
+
+        char *transport_error = NULL;
+
+        request_json = cJSON_CreateObject();
+
+        if (!request_json) {
+            state_set_error(
+                "Out of memory creating OpenAI poll request");
+            break;
+        }
+
+        cJSON_AddStringToObject(
+            request_json,
+            "device_auth_id",
+            poll->device_auth_id);
+
+        cJSON_AddStringToObject(
+            request_json,
+            "user_code",
+            poll->user_code);
+
+        request_body =
+            cJSON_PrintUnformatted(request_json);
+
+        cJSON_Delete(request_json);
+        request_json = NULL;
+
+        if (!request_body) {
+            state_set_error(
+                "Out of memory serializing OpenAI poll request");
+            break;
+        }
+
+        request.url =
+            OPENAI_CODEX_DEVICE_TOKEN_URL;
+
+        request.body =
+            request_body;
+
+        request.content_type =
+            "application/json";
+
+        request.accept_non_200 =
+            true;
+
+        request.timeout_ms =
+            OPENAI_CODEX_HTTP_TIMEOUT_MS;
+
+        esp_err_t err =
+            claw_llm_http_post_json(
+                &request,
+                &response,
+                &transport_error);
+
+        free(request_body);
+        request_body = NULL;
+
+        if (s_cancel_requested) {
+            free(transport_error);
+            claw_llm_http_response_free(&response);
+            break;
+        }
+
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG,
+                     "Device-auth poll transport failed: %s",
+                     transport_error
+                        ? transport_error
+                        : esp_err_to_name(err));
+
+            free(transport_error);
+            claw_llm_http_response_free(&response);
+
+            state_set_error(
+                "OpenAI device-auth polling failed");
+            break;
+        }
+
+        free(transport_error);
+        transport_error = NULL;
+
+        if (response.status_code >= 200 &&
+                response.status_code < 300) {
+
+            cJSON *root =
+                cJSON_Parse(response.body
+                                ? response.body
+                                : "");
+
+            if (!root) {
+                claw_llm_http_response_free(&response);
+
+                state_set_error(
+                    "Could not parse OpenAI authorization response");
+                break;
+            }
+
+            const char *authorization_code =
+                cJSON_GetStringValue(
+                    cJSON_GetObjectItemCaseSensitive(
+                        root,
+                        "authorization_code"));
+
+            const char *code_challenge =
+                cJSON_GetStringValue(
+                    cJSON_GetObjectItemCaseSensitive(
+                        root,
+                        "code_challenge"));
+
+            const char *code_verifier =
+                cJSON_GetStringValue(
+                    cJSON_GetObjectItemCaseSensitive(
+                        root,
+                        "code_verifier"));
+
+            if (!authorization_code ||
+                    !authorization_code[0] ||
+                    !code_challenge ||
+                    !code_challenge[0] ||
+                    !code_verifier ||
+                    !code_verifier[0]) {
+
+                cJSON_Delete(root);
+                claw_llm_http_response_free(&response);
+
+                state_set_error(
+                    "OpenAI authorization response is incomplete");
+                break;
+            }
+
+            char *authorization_code_copy =
+                strdup(authorization_code);
+
+            char *code_verifier_copy =
+                strdup(code_verifier);
+
+            cJSON_Delete(root);
+            claw_llm_http_response_free(&response);
+
+            if (!authorization_code_copy ||
+                    !code_verifier_copy) {
+
+                free(authorization_code_copy);
+                free(code_verifier_copy);
+
+                state_set_error(
+                    "Out of memory processing OpenAI authorization");
+                break;
+            }
+
+            if (s_cancel_requested) {
+                free(authorization_code_copy);
+                free(code_verifier_copy);
+                break;
+            }
+
+            state_lock();
+
+            strlcpy(s_login.status,
+                    "exchanging",
+                    sizeof(s_login.status));
+
+            strlcpy(s_login.message,
+                    "Finishing ChatGPT login",
+                    sizeof(s_login.message));
+
+            state_unlock();
+
+            err = exchange_authorization_code(
+                authorization_code_copy,
+                code_verifier_copy);
+
+            free(authorization_code_copy);
+            free(code_verifier_copy);
+
+            if (err != ESP_OK) {
+                state_set_error(
+                    "ChatGPT token exchange failed");
+            }
+
+            break;
+        }
+
+        if (response.status_code != 403 &&
+                response.status_code != 404) {
+
+            char message[96];
+
+            snprintf(
+                message,
+                sizeof(message),
+                "OpenAI device auth failed with HTTP %d",
+                response.status_code);
+
+            claw_llm_http_response_free(&response);
+
+            state_set_error(message);
+            break;
+        }
+
+        claw_llm_http_response_free(&response);
+
+        TickType_t elapsed_ticks =
+            xTaskGetTickCount() - start_tick;
+
+        uint64_t elapsed_ms =
+            (uint64_t)elapsed_ticks *
+            (uint64_t)portTICK_PERIOD_MS;
+
+        if (elapsed_ms >=
+                ((uint64_t)OPENAI_CODEX_MAX_LOGIN_SECONDS *
+                 1000ULL)) {
+
+            state_set_error(
+                "ChatGPT login timed out after 15 minutes");
+            break;
+        }
+
+        uint32_t interval =
+            poll->interval
+                ? poll->interval
+                : OPENAI_CODEX_DEFAULT_INTERVAL;
+
+        vTaskDelay(
+            pdMS_TO_TICKS(interval * 1000U));
+    }
+
+    free(poll);
+
+    worker_finished();
+
+    vTaskDelete(NULL);
+}
+
+
+esp_err_t claw_openai_codex_auth_get_session(char **out_access_token,
+                                              char **out_account_id)
+{
+    if (!out_access_token || !out_account_id) return ESP_ERR_INVALID_ARG;
+    *out_access_token = NULL;
+    *out_account_id = NULL;
+
+    esp_err_t err = ensure_state_lock();
+    if (err != ESP_OK) return err;
+
+    state_lock();
+    if (!s_login.completed || strcmp(s_login.status, "connected") != 0 ||
+            !s_access_token || !s_access_token[0]) {
+        state_unlock();
+        return ESP_ERR_INVALID_STATE;
+    }
+    char *access_token = strdup(s_access_token);
+    state_unlock();
+    if (!access_token) return ESP_ERR_NO_MEM;
+
+    char *account_id = NULL;
+    err = claw_openai_codex_store_load_account_id(&account_id);
+    if (err == ESP_ERR_NOT_FOUND || !account_id || !account_id[0]) {
+        free(account_id);
+        account_id = extract_chatgpt_account_id(access_token);
+        if (!account_id) { free(access_token); return ESP_ERR_NOT_FOUND; }
+        esp_err_t save_err = claw_openai_codex_store_save_account_id(account_id);
+        if (save_err != ESP_OK) {
+            ESP_LOGW(TAG, "Could not persist recovered ChatGPT account id: %s", esp_err_to_name(save_err));
+        }
+        err = ESP_OK;
+    }
+    if (err != ESP_OK) { free(access_token); free(account_id); return err; }
+
+    *out_access_token = access_token;
+    *out_account_id = account_id;
+    return ESP_OK;
+}
+esp_err_t claw_openai_codex_login_start(void)
+{
+    esp_err_t err =
+        ensure_state_lock();
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    state_lock();
+
+    if (s_worker_running) {
+        state_unlock();
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    s_cancel_requested = false;
+
+    memset(&s_login, 0, sizeof(s_login));
+
+    s_login.active = true;
+
+    strlcpy(s_login.status,
+            "requesting",
+            sizeof(s_login.status));
+
+    strlcpy(s_login.message,
+            "Requesting ChatGPT device code",
+            sizeof(s_login.message));
+
+    state_unlock();
+
+    claw_llm_http_json_request_t request = {0};
+    claw_llm_http_response_t response = {0};
+
+    char *transport_error = NULL;
+
+    request.url =
+        OPENAI_CODEX_DEVICE_CODE_URL;
+
+    request.body =
+        "{\"client_id\":\""
+        OPENAI_CODEX_CLIENT_ID
+        "\"}";
+
+    request.content_type =
+        "application/json";
+
+    request.timeout_ms =
+        OPENAI_CODEX_HTTP_TIMEOUT_MS;
+
+    err =
+        claw_llm_http_post_json(
+            &request,
+            &response,
+            &transport_error);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "Device-code request failed: %s",
+                 transport_error
+                    ? transport_error
+                    : esp_err_to_name(err));
+
+        free(transport_error);
+
+        state_set_error(
+            "Could not contact OpenAI authentication server");
+
+        claw_llm_http_response_free(&response);
+
+        return err;
+    }
+
+    free(transport_error);
+
+    cJSON *root =
+        cJSON_Parse(response.body
+                        ? response.body
+                        : "");
+
+    if (!root) {
+        claw_llm_http_response_free(&response);
+
+        state_set_error(
+            "Could not parse OpenAI device-code response");
+
+        return ESP_FAIL;
+    }
+
+    const char *device_auth_id =
+        cJSON_GetStringValue(
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "device_auth_id"));
+
+    cJSON *user_code_item =
+        cJSON_GetObjectItemCaseSensitive(
+            root,
+            "user_code");
+
+    if (!cJSON_IsString(user_code_item)) {
+        user_code_item =
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "usercode");
+    }
+
+    const char *user_code =
+        cJSON_GetStringValue(user_code_item);
+
+    uint32_t interval =
+        parse_interval(
+            cJSON_GetObjectItemCaseSensitive(
+                root,
+                "interval"));
+
+    if (!device_auth_id ||
+            !device_auth_id[0] ||
+            !user_code ||
+            !user_code[0]) {
+
+        cJSON_Delete(root);
+        claw_llm_http_response_free(&response);
+
+        state_set_error(
+            "OpenAI device-code response is incomplete");
+
+        return ESP_FAIL;
+    }
+
+    openai_codex_poll_args_t *poll =
+        calloc(1, sizeof(*poll));
+
+    if (!poll) {
+        cJSON_Delete(root);
+        claw_llm_http_response_free(&response);
+
+        state_set_error(
+            "Out of memory starting ChatGPT login");
+
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (strlen(device_auth_id) >=
+            sizeof(poll->device_auth_id) ||
+        strlen(user_code) >=
+            sizeof(poll->user_code)) {
+
+        free(poll);
+        cJSON_Delete(root);
+        claw_llm_http_response_free(&response);
+
+        state_set_error(
+            "OpenAI device-code response is too large");
+
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    strlcpy(
+        poll->device_auth_id,
+        device_auth_id,
+        sizeof(poll->device_auth_id));
+
+    strlcpy(
+        poll->user_code,
+        user_code,
+        sizeof(poll->user_code));
+
+    poll->interval = interval;
+
+    state_lock();
+
+    s_login.active = true;
+    s_login.completed = false;
+    s_login.interval = interval;
+
+    strlcpy(
+        s_login.user_code,
+        user_code,
+        sizeof(s_login.user_code));
+
+    strlcpy(
+        s_login.verification_url,
+        OPENAI_CODEX_VERIFICATION_URL,
+        sizeof(s_login.verification_url));
+
+    strlcpy(
+        s_login.status,
+        "waiting",
+        sizeof(s_login.status));
+
+    strlcpy(
+        s_login.message,
+        "Waiting for ChatGPT authorization",
+        sizeof(s_login.message));
+
+    s_worker_running = true;
+
+    state_unlock();
+
+    cJSON_Delete(root);
+    claw_llm_http_response_free(&response);
+
+    BaseType_t task_ok =
+        xTaskCreate(
+            openai_codex_poll_task,
+            "codex_oauth",
+            OPENAI_CODEX_POLL_TASK_STACK,
+            poll,
+            OPENAI_CODEX_POLL_TASK_PRIORITY,
+            NULL);
+
+    if (task_ok != pdPASS) {
+        state_lock();
+        s_worker_running = false;
+        state_unlock();
+
+        free(poll);
+
+        state_set_error(
+            "Could not start ChatGPT login task");
+
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(
+        TAG,
+        "OpenAI device login started; poll interval=%u seconds",
+        (unsigned)interval);
+
+    return ESP_OK;
+}
+
+
+esp_err_t claw_openai_codex_login_get_status(
+    claw_openai_codex_login_status_t *status)
+{
+    esp_err_t err =
+        ensure_state_lock();
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (!status) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    state_lock();
+
+    memset(status, 0, sizeof(*status));
+
+    status->active =
+        s_login.active;
+
+    status->completed =
+        s_login.completed;
+
+    status->interval =
+        s_login.interval;
+
+    strlcpy(
+        status->status,
+        s_login.status,
+        sizeof(status->status));
+
+    strlcpy(
+        status->message,
+        s_login.message,
+        sizeof(status->message));
+
+    strlcpy(
+        status->user_code,
+        s_login.user_code,
+        sizeof(status->user_code));
+
+    strlcpy(
+        status->verification_url,
+        s_login.verification_url,
+        sizeof(status->verification_url));
+
+    state_unlock();
+
+    return ESP_OK;
+}
+
+
+esp_err_t claw_openai_codex_login_cancel(void)
+{
+    esp_err_t err =
+        ensure_state_lock();
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    state_lock();
+
+    /*
+     * Do not turn an already completed login into "cancelled".
+     * This endpoint only cancels an active login attempt.
+     */
+    if (!s_worker_running) {
+        state_unlock();
+        return ESP_OK;
+    }
+
+    s_cancel_requested = true;
+
+    s_login.active = false;
+    s_login.completed = false;
+
+    strlcpy(
+        s_login.status,
+        "cancelled",
+        sizeof(s_login.status));
+
+    strlcpy(
+        s_login.message,
+        "ChatGPT login cancelled",
+        sizeof(s_login.message));
+
+    state_unlock();
+
+    return ESP_OK;
+}

--- a/components/claw_modules/claw_core/src/llm/claw_openai_codex_store.c
+++ b/components/claw_modules/claw_core/src/llm/claw_openai_codex_store.c
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "llm/claw_openai_codex_store.h"
+
+#include <stdlib.h>
+
+#include "esp_log.h"
+#include "nvs.h"
+
+#define CODEX_NVS_NAMESPACE "codex_auth"
+#define CODEX_NVS_KEY_REFRESH "refresh"
+#define CODEX_NVS_KEY_ACCOUNT "account"
+
+static const char *TAG = "codex_store";
+
+esp_err_t claw_openai_codex_store_save_refresh_token(const char *token)
+{
+    if (!token || !token[0]) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open(CODEX_NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = nvs_set_str(handle, CODEX_NVS_KEY_REFRESH, token);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to save refresh token: %s", esp_err_to_name(err));
+    }
+
+    nvs_close(handle);
+    return err;
+}
+
+esp_err_t claw_openai_codex_store_load_refresh_token(char **out_token)
+{
+    if (!out_token) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *out_token = NULL;
+
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open(CODEX_NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    size_t needed = 0;
+    err = nvs_get_str(handle, CODEX_NVS_KEY_REFRESH, NULL, &needed);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        nvs_close(handle);
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (err != ESP_OK) {
+        nvs_close(handle);
+        return err;
+    }
+
+    char *token = calloc(1, needed);
+    if (!token) {
+        nvs_close(handle);
+        return ESP_ERR_NO_MEM;
+    }
+
+    err = nvs_get_str(handle, CODEX_NVS_KEY_REFRESH, token, &needed);
+    nvs_close(handle);
+
+    if (err != ESP_OK) {
+        free(token);
+        return err;
+    }
+
+    *out_token = token;
+    return ESP_OK;
+}
+
+esp_err_t claw_openai_codex_store_save_account_id(const char *account_id)
+{
+    if (!account_id || !account_id[0]) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open(CODEX_NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = nvs_set_str(handle, CODEX_NVS_KEY_ACCOUNT, account_id);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to save account id: %s", esp_err_to_name(err));
+    }
+
+    nvs_close(handle);
+    return err;
+}
+
+esp_err_t claw_openai_codex_store_load_account_id(char **out_account_id)
+{
+    if (!out_account_id) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *out_account_id = NULL;
+
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open(CODEX_NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    size_t needed = 0;
+    err = nvs_get_str(handle, CODEX_NVS_KEY_ACCOUNT, NULL, &needed);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        nvs_close(handle);
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (err != ESP_OK) {
+        nvs_close(handle);
+        return err;
+    }
+
+    char *account_id = calloc(1, needed);
+    if (!account_id) {
+        nvs_close(handle);
+        return ESP_ERR_NO_MEM;
+    }
+
+    err = nvs_get_str(handle, CODEX_NVS_KEY_ACCOUNT, account_id, &needed);
+    nvs_close(handle);
+
+    if (err != ESP_OK) {
+        free(account_id);
+        return err;
+    }
+
+    *out_account_id = account_id;
+    return ESP_OK;
+}
+
+esp_err_t claw_openai_codex_store_erase(void)
+{
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open(CODEX_NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        return ESP_OK;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = nvs_erase_all(handle);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+
+    nvs_close(handle);
+    return err;
+}

--- a/components/claw_modules/claw_core/src/llm/claw_openai_codex_store.h
+++ b/components/claw_modules/claw_core/src/llm/claw_openai_codex_store.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_err.h"
+
+esp_err_t claw_openai_codex_store_save_refresh_token(const char *token);
+esp_err_t claw_openai_codex_store_load_refresh_token(char **out_token);
+esp_err_t claw_openai_codex_store_save_account_id(const char *account_id);
+esp_err_t claw_openai_codex_store_load_account_id(char **out_account_id);
+esp_err_t claw_openai_codex_store_erase(void);


### PR DESCRIPTION
## Description

This PR adds an experimental `openai_codex` LLM backend for ESP-Claw using ChatGPT OAuth and the Codex Responses transport instead of API-key authentication through an OpenAI-compatible endpoint.

The implementation keeps the existing ESP-Claw agent and capability/tool execution loop intact and adapts the Codex Responses wire format to the existing `claw_llm_*` abstractions.

### Main changes

- Add ChatGPT OAuth login/start/status/cancel flow
- Persist and restore the OAuth session across device reboots
- Add an `openai_codex` LLM backend using the Codex Responses endpoint
- Serialize ESP-Claw conversation messages to Responses input items
- Convert ESP-Claw function definitions to the Responses function-tool schema
- Map Responses `function_call` items to `claw_llm_tool_call_t`
- Convert tool execution results back to `function_call_output`
- Preserve typed Responses output items between tool rounds
- Support stateless reasoning continuation with `reasoning.encrypted_content`
- Add HTTP endpoints for starting and monitoring ChatGPT OAuth login

## Motivation and Context

ESP-Claw already supports OpenAI-compatible LLM backends using API-key authentication.

ChatGPT OAuth / Codex uses a different authentication mechanism and the Responses protocol, including typed `function_call` and `function_call_output` items.

This implementation isolates those differences in a separate backend and authentication layer while reusing ESP-Claw's existing agent and capability execution infrastructure.

## Testing

Tested on an M5Stack CoreS3 / ESP32-S3.

Verified:

- ESP-IDF build completes successfully
- ChatGPT OAuth login completes successfully
- OAuth authentication is restored after reboot
- normal text completion works
- single tool-call round works with `get_system_info`
- sequential multi-round tool execution works:
  - `get_system_info`
  - `get_current_time`
  - final assistant response incorporating both tool results

The text regression test returned the expected response:

`STAGE4 TEXT OK`

The multi-round test successfully executed both capabilities before producing the final assistant response.

## Notes

This PR is intentionally submitted as a draft.

The implementation currently uses:

`https://chatgpt.com/backend-api/codex/responses`

This is a ChatGPT/Codex backend endpoint rather than the public OpenAI API, so its endpoint URL, authentication behavior, or protocol details may be less stable. Feedback on whether this backend is suitable for upstream inclusion, should remain experimental, or should be structured differently is welcome.

`parallel_tool_calls` is currently disabled so capability execution remains sequential and matches the existing tested ESP-Claw agent loop.

Board-specific CoreS3 SD/SPI and power-management changes from the development setup are intentionally not included in this PR.
