### PR TITLE
fix: PSRAM-stack flash-cache crash and http_reuse use-after-free

### DIFF
--- a/components/claw_modules/claw_core/src/claw_core.c
+++ b/components/claw_modules/claw_core/src/claw_core.c
@@ -225,7 +225,14 @@ esp_err_t claw_core_start(claw_core_handle_t core)
                                         .stack_size = core->task_stack_size,
                                         .priority = core->task_priority,
                                         .core_id = core->task_core,
-                                        .stack_policy = CLAW_TASK_STACK_PREFER_PSRAM,
+                                        /* Must be internal RAM: the agent loop's request-gate
+                                         * callback chain (claw_memory_session's session-history
+                                         * check) performs raw flash reads, which briefly disable
+                                         * the flash cache. A PSRAM-backed stack becomes
+                                         * unreachable during that window —
+                                         * esp_task_stack_is_sane_cache_disabled() asserts and
+                                         * reboots the device on every such read. */
+                                        .stack_policy = CLAW_TASK_STACK_INTERNAL_ONLY,
                                     },
                                     claw_core_agent_loop_task,
                                     core,

--- a/components/claw_modules/claw_event_router/src/claw_event_router.c
+++ b/components/claw_modules/claw_event_router/src/claw_event_router.c
@@ -2379,7 +2379,13 @@ esp_err_t claw_event_router_start(void)
                                    .stack_size = stack_size,
                                    .priority = priority,
                                    .core_id = core,
-                                   .stack_policy = CLAW_TASK_STACK_PREFER_PSRAM,
+                                   /* Must be internal RAM: this task performs raw flash
+                                    * reads (fopen()/wear-levelling FAT I/O for session and
+                                    * agent management), which briefly disables the flash
+                                    * cache. A PSRAM-backed stack becomes unreachable during
+                                    * that window — esp_task_stack_is_sane_cache_disabled()
+                                    * asserts and reboots the device on every such read. */
+                                   .stack_policy = CLAW_TASK_STACK_INTERNAL_ONLY,
                                },
                                claw_event_router_task,
                                NULL,

--- a/components/claw_modules/claw_memory/src/claw_memory_session.c
+++ b/components/claw_modules/claw_memory/src/claw_memory_session.c
@@ -476,7 +476,12 @@ esp_err_t claw_memory_async_extract_init(const claw_memory_config_t *config)
                                         .stack_size = CLAW_MEMORY_ASYNC_EXTRACT_STACK_SIZE,
                                         .priority = CLAW_MEMORY_ASYNC_EXTRACT_PRIORITY,
                                         .core_id = tskNO_AFFINITY,
-                                        .stack_policy = CLAW_TASK_STACK_PREFER_PSRAM,
+                                        /* Must be internal RAM: this task reads/writes session
+                                         * history files on flash, which briefly disables the
+                                         * flash cache. A PSRAM-backed stack becomes unreachable
+                                         * during that window — esp_task_stack_is_sane_cache_disabled()
+                                         * asserts and reboots the device on every such read. */
+                                        .stack_policy = CLAW_TASK_STACK_INTERNAL_ONLY,
                                     },
                                     claw_memory_async_extract_task,
                                     NULL,

--- a/components/common/app_claw/app_claw.c
+++ b/components/common/app_claw/app_claw.c
@@ -701,7 +701,16 @@ esp_err_t app_claw_start(const app_claw_config_t *config)
 #if CONFIG_APP_CLAW_CAP_EVENT_ROUTER
     claw_event_router_config_t router_config = {
         .rules_path = NULL,
-        .task_stack_size = 8 * 1024,
+        /* 16KB, not 8KB: with an internal-RAM task stack (required so raw
+         * flash/FAT reads don't hit an unreachable PSRAM stack mid-read,
+         * see claw_event_router_start()'s CLAW_TASK_STACK_INTERNAL_ONLY),
+         * this task's real high-water mark for a full message-event
+         * processing path (session/agent file I/O, JSON build) exceeds 8KB
+         * and overflows. That was previously masked because such
+         * deployments crashed earlier via
+         * esp_task_stack_is_sane_cache_disabled() before ever reaching
+         * this depth. */
+        .task_stack_size = 16 * 1024,
         .task_priority = 5,
         .task_core = tskNO_AFFINITY,
         .agent_submit_timeout_ms = 1000,

--- a/components/common/http_reuse/esp_http_client_reuse.c
+++ b/components/common/http_reuse/esp_http_client_reuse.c
@@ -12,9 +12,9 @@
 #include "esp_http_client.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
-#include "freertos/timers.h"
 #include "sdkconfig.h"
 
 #if CONFIG_HTTP_REUSE_ENABLE
@@ -65,10 +65,30 @@ static STAILQ_HEAD(http_reuse_lease_head, http_reuse_lease)
     s_leases = STAILQ_HEAD_INITIALIZER(s_leases);
 
 static SemaphoreHandle_t s_pool_mutex          = NULL;
-static TimerHandle_t     s_pool_reaper_timer   = NULL;
 static portMUX_TYPE      s_pool_mutex_init_mux = portMUX_INITIALIZER_UNLOCKED;
 
-static void pool_reap_idle_timer_cb(TimerHandle_t timer);
+/*
+ * Idle-eviction close-off task. Idle reaping used to run on a periodic
+ * FreeRTOS software timer, i.e. the Timer Service task, which only has
+ * CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH bytes of stack (2048 by default).
+ * Even just the ESP_LOGI() call in pool_reap_idle_locked() does not
+ * reliably fit in that budget (confirmed by a stack-overflow panic with the
+ * log line cut off mid-print), let alone __real_esp_http_client_cleanup()
+ * tearing down a socket/transport. So nothing pool-related runs on the
+ * Timer Service task at all: this dedicated task both drains handles handed
+ * off for destruction and self-drives the periodic idle reap (via the
+ * xQueueReceive timeout below), entirely off Tmr Svc. Sized generously
+ * because it also has to close TLS (Telegram) pooled connections, whose
+ * mbedTLS teardown is deeper than a plain socket close.
+ */
+#define HTTP_REUSE_CLOSE_TASK_STACK_SIZE 8192
+#define HTTP_REUSE_CLOSE_TASK_PRIORITY   (tskIDLE_PRIORITY + 1)
+
+static QueueHandle_t s_close_queue = NULL;
+static TaskHandle_t  s_close_task  = NULL;
+
+static void close_task_fn(void *arg);
+static void pool_reap_idle_locked(void);
 
 static TickType_t pool_idle_timeout_ticks(void)
 {
@@ -103,36 +123,43 @@ static void endpoint_release(http_reuse_endpoint_t *ep)
 
 static void pool_mutex_take(void)
 {
-    TimerHandle_t new_timer = NULL;
-
     portENTER_CRITICAL(&s_pool_mutex_init_mux);
     if (s_pool_mutex == NULL) {
         s_pool_mutex = xSemaphoreCreateMutex();
     }
     portEXIT_CRITICAL(&s_pool_mutex_init_mux);
 
-    if (s_pool_reaper_timer == NULL) {
-        new_timer = xTimerCreate("http_reuse_gc",
-                                 pool_reaper_period_ticks(),
-                                 pdTRUE,
-                                 NULL,
-                                 pool_reap_idle_timer_cb);
-        if (new_timer != NULL) {
+    if (s_close_queue == NULL) {
+        QueueHandle_t new_queue = xQueueCreate(CONFIG_HTTP_REUSE_MAX_POOL, sizeof(esp_http_client_handle_t));
+        if (new_queue != NULL) {
             portENTER_CRITICAL(&s_pool_mutex_init_mux);
-            if (s_pool_reaper_timer == NULL) {
-                s_pool_reaper_timer = new_timer;
-                new_timer = NULL;
+            if (s_close_queue == NULL) {
+                s_close_queue = new_queue;
+                new_queue     = NULL;
             }
             portEXIT_CRITICAL(&s_pool_mutex_init_mux);
-            if (new_timer != NULL) {
-                (void)xTimerDelete(new_timer, 0);
+            if (new_queue != NULL) {
+                vQueueDelete(new_queue);
             }
         }
     }
 
-    if (s_pool_reaper_timer && xTimerIsTimerActive(s_pool_reaper_timer) == pdFALSE) {
-        (void)xTimerStart(s_pool_reaper_timer, 0);
+    if (s_close_queue != NULL && s_close_task == NULL) {
+        TaskHandle_t new_task = NULL;
+        if (xTaskCreate(close_task_fn, "http_reuse_close", HTTP_REUSE_CLOSE_TASK_STACK_SIZE,
+                        NULL, HTTP_REUSE_CLOSE_TASK_PRIORITY, &new_task) == pdPASS) {
+            portENTER_CRITICAL(&s_pool_mutex_init_mux);
+            if (s_close_task == NULL) {
+                s_close_task = new_task;
+                new_task     = NULL;
+            }
+            portEXIT_CRITICAL(&s_pool_mutex_init_mux);
+            if (new_task != NULL) {
+                vTaskDelete(new_task);
+            }
+        }
     }
+
     if (s_pool_mutex) {
         xSemaphoreTake(s_pool_mutex, portMAX_DELAY);
     }
@@ -282,6 +309,29 @@ static void node_free(http_reuse_node_t *node, bool destroy_client)
     free(node);
 }
 
+/**
+ * Runs on a dedicated task. Drains client handles handed off by
+ * pool_reap_idle_locked() for destruction; when idle for one reaper period,
+ * self-drives the next idle reap pass instead of relying on a software
+ * timer (which would run reap on the tiny Timer Service stack).
+ */
+static void close_task_fn(void *arg)
+{
+    (void)arg;
+    esp_http_client_handle_t client;
+
+    while (1) {
+        if (xQueueReceive(s_close_queue, &client, pool_reaper_period_ticks()) == pdTRUE) {
+            __real_esp_http_client_cleanup(client);
+        } else {
+            pool_mutex_take();
+            pool_reap_idle_locked();
+            pool_mutex_give();
+        }
+    }
+}
+
+/** Caller must hold @ref s_pool_mutex. */
 static void pool_reap_idle_locked(void)
 {
     TickType_t         now = xTaskGetTickCount();
@@ -308,17 +358,13 @@ static void pool_reap_idle_locked(void)
                  node->endpoint.port,
                  (unsigned)(idle_ticks * portTICK_PERIOD_MS));
         STAILQ_REMOVE(&s_pool, node, http_reuse_node, list);
-        node_free(node, true);
+        if (s_close_queue != NULL && xQueueSend(s_close_queue, &node->client, 0) == pdTRUE) {
+            node_free(node, false);
+        } else {
+            ESP_LOGW(TAG, "close queue unavailable, destroying %p inline", node->client);
+            node_free(node, true);
+        }
     }
-}
-
-static void pool_reap_idle_timer_cb(TimerHandle_t timer)
-{
-    (void)timer;
-
-    pool_mutex_take();
-    pool_reap_idle_locked();
-    pool_mutex_give();
 }
 
 static esp_http_client_handle_t pool_take_locked(const http_reuse_endpoint_t *target)
@@ -672,6 +718,17 @@ esp_err_t __wrap_esp_http_client_cleanup(esp_http_client_handle_t client)
         node->reused_in_current_lease = false; /* lease ended */
         node->last_update_ticks       = xTaskGetTickCount();
         pool_mutex_give();
+        /*
+         * event_handler/user_data still reference the caller's just-finished
+         * request (often a stack-local context). esp_http_client_close/
+         * cleanup dispatch HTTP_EVENT_DISCONNECTED through them, so an idle
+         * pooled client left with a stale pointer here crashes (use-after-
+         * free) whenever it's later evicted or destroyed instead of reused.
+         * pool_take_locked's reuse-hit path in __wrap_esp_http_client_init
+         * always re-sets both before the client is used again.
+         */
+        esp_http_client_set_event_handler(client, NULL);
+        esp_http_client_set_user_data(client, NULL);
         ESP_LOGD(TAG, "idle persistent in pool %p", client);
         return ESP_OK;
     }
@@ -706,6 +763,10 @@ esp_err_t __wrap_esp_http_client_cleanup(esp_http_client_handle_t client)
         endpoint_release(&ep);
         return __real_esp_http_client_cleanup(client);
     }
+    /* See the matching comment in the in_pool branch above: clear the
+     * caller's event_handler/user_data before this client is left idle. */
+    esp_http_client_set_event_handler(client, NULL);
+    esp_http_client_set_user_data(client, NULL);
     ESP_LOGD(TAG, "insert idle persistent %p", client);
     return ESP_OK;
 }


### PR DESCRIPTION
## Summary

Two crash-level bugs found and fixed while bringing up a new application
on an ESP32-S3 board with octal PSRAM:

- **PSRAM task stacks + flash cache disable.** Any task created with
  `CLAW_TASK_STACK_PREFER_PSRAM` that also performs raw flash reads
  (`fopen()`/wear-levelling FAT I/O) can crash: the flash read briefly
  disables the flash cache, and a PSRAM-backed stack is unreachable during
  that window, so `esp_task_stack_is_sane_cache_disabled()` asserts and
  reboots the device. This affects three built-in tasks that all do file
  I/O as part of normal operation: `claw_core`'s agent loop,
  `claw_event_router`'s dispatch task, and `claw_memory`'s async
  session-extract task. Fixed by switching those three (and only those
  three) to `CLAW_TASK_STACK_INTERNAL_ONLY`, plus a stack-size bump for
  `claw_event_router`'s task once the crash no longer masked its real
  high-water mark.

- **`http_reuse` use-after-free.** A pooled idle HTTP client kept the
  `event_handler`/`user_data` from its last caller, which is commonly a
  stack-local context valid only for the duration of one
  `esp_http_client_perform()` call. `esp_http_client_close()`/`cleanup()`
  dispatch an event through that handler before doing anything else, so
  destroying (or evicting) an idle pooled client after its original caller
  returned reads through a dangling pointer. Any app that makes at least
  one keep-alive HTTP request and then goes idle past
  `CONFIG_HTTP_REUSE_IDLE_TIMEOUT_SEC` (default 60s) reboots itself on the
  next idle eviction. Fixed by clearing `event_handler`/`user_data` before
  leaving a client idle in the pool (reuse already re-sets both from the
  new caller before handing it back out). Also moves idle-eviction reaping
  off the Timer Service task's small default stack onto a dedicated task.

## Test plan
- [x] Reproduced both crashes on ESP32-S3 (octal PSRAM) hardware before
      the fix, confirmed gone after, across multiple rounds each.
- [x] `pio run` / `idf.py build` clean.

Each commit is self-contained; happy to split further or adjust framing if useful.